### PR TITLE
Nest FanGraphs projections under `projections` and prefer ESPN values over Savant in `current_season`

### DIFF
--- a/player_universe_trx/matchers/player_matcher.py
+++ b/player_universe_trx/matchers/player_matcher.py
@@ -18,10 +18,16 @@ from player_universe_trx.models.fangraphs import (
     FangraphsPitcherModel,
     FangraphsPlayerModel,
 )
+from player_universe_trx.models.fangraphs.stats import (
+    FangraphsBatterStatsModel,
+    FangraphsPitcherStatsModel,
+)
 from player_universe_trx.models.mtbl import (
     MtblBatterModel,
+    MtblBatterSeasonStatsModel,
     MtblBatterStatsModel,
     MtblPitcherModel,
+    MtblPitcherSeasonStatsModel,
     MtblPitcherStatsModel,
     MtblPlayerModel,
 )
@@ -784,19 +790,18 @@ def _extract_espn_current_season_stats(
 def _extract_fangraphs_projections(
     fg_match: Optional["FangraphsBatterModel | FangraphsPitcherModel"],
 ) -> Dict[str, Any]:
-    """Extract FanGraphs projection stats with proj_ prefix.
+    """Extract FanGraphs projection stats.
 
     Args:
         fg_match: FanGraphs player model with projections
 
     Returns:
-        Dictionary of projection stats (all keys prefixed with proj_)
+        Dictionary of projection stats
     """
     if not fg_match or not fg_match.projection:
         return {}
 
-    fg_proj: Dict[str, Any] = fg_match.projection.model_dump(exclude_none=True)
-    return {f"proj_{key}": value for key, value in fg_proj.items()}
+    return fg_match.projection.model_dump(exclude_none=True)
 
 
 def _extract_savant_stats(
@@ -819,33 +824,29 @@ def _build_stats_dict(
     result: PlayerMatchResult,
     is_matched: bool,
 ) -> Dict[str, Any]:
-    """Build combined stats dictionary from all sources.
+    """Build combined current-season stats dictionary from all sources.
 
     Args:
         result: Player match result containing ESPN, FanGraphs, and Savant data
         is_matched: Whether player has FanGraphs/Savant matches
 
     Returns:
-        Dictionary combining stats from all sources
+        Dictionary combining current-season stats from ESPN and Savant
     """
     stats_dict: Dict[str, Any] = {}
 
-    # 1. ESPN current season stats (unprefixed, top level)
+    # 1. ESPN current season stats (unprefixed)
     espn_current: Dict[str, Any] = _extract_espn_current_season_stats(
         result.espn_player
     )
     stats_dict.update(espn_current)
 
     if is_matched:
-        # 2. FanGraphs projections (prefixed with proj_)
-        fg_projections: Dict[str, Any] = _extract_fangraphs_projections(
-            result.fangraphs_match
-        )
-        stats_dict.update(fg_projections)
-
-        # 3. Savant sabermetrics (unprefixed)
+        # 2. Savant sabermetrics (unprefixed), keep ESPN values on collision
         savant_stats: Dict[str, Any] = _extract_savant_stats(result.savant_match)
-        stats_dict.update(savant_stats)
+        for key, value in savant_stats.items():
+            if key not in stats_dict:
+                stats_dict[key] = value
 
     return stats_dict
 
@@ -853,6 +854,7 @@ def _build_stats_dict(
 def _create_player_model(
     base_player: MtblPlayerModel,
     stats_dict: Dict[str, Any],
+    projections_dict: Dict[str, Any],
     espn_stats_container: Optional[EspnBatterStats | EspnPitcherStats],
     is_batter: bool,
 ) -> MtblPlayerModel:
@@ -860,7 +862,8 @@ def _create_player_model(
 
     Args:
         base_player: Base MTBL player model
-        stats_dict: Combined stats dictionary
+        stats_dict: Combined current season stats dictionary
+        projections_dict: FanGraphs projections dictionary
         espn_stats_container: ESPN stats container with all periods
         is_batter: True for batter, False for pitcher
 
@@ -871,21 +874,41 @@ def _create_player_model(
 
     if is_batter:
         batter_stats: Optional[MtblBatterStatsModel] = None
-        if stats_dict or espn_stats_container:
+        if stats_dict or projections_dict or espn_stats_container:
             # Type narrow the container for batters
             batter_container: Optional[EspnBatterStats] = (
                 espn_stats_container if isinstance(espn_stats_container, EspnBatterStats) else None
             )
-            batter_stats = MtblBatterStatsModel(**stats_dict, espn_stats=batter_container)
+            current_season: Optional[MtblBatterSeasonStatsModel] = (
+                MtblBatterSeasonStatsModel(**stats_dict) if stats_dict else None
+            )
+            projections: Optional[FangraphsBatterStatsModel] = (
+                FangraphsBatterStatsModel(**projections_dict) if projections_dict else None
+            )
+            batter_stats = MtblBatterStatsModel(
+                current_season=current_season,
+                projections=projections,
+                espn_stats=batter_container,
+            )
         return MtblBatterModel(**base_data, stats=batter_stats)
     else:
         pitcher_stats: Optional[MtblPitcherStatsModel] = None
-        if stats_dict or espn_stats_container:
+        if stats_dict or projections_dict or espn_stats_container:
             # Type narrow the container for pitchers
             pitcher_container: Optional[EspnPitcherStats] = (
                 espn_stats_container if isinstance(espn_stats_container, EspnPitcherStats) else None
             )
-            pitcher_stats = MtblPitcherStatsModel(**stats_dict, espn_stats=pitcher_container)
+            current_season: Optional[MtblPitcherSeasonStatsModel] = (
+                MtblPitcherSeasonStatsModel(**stats_dict) if stats_dict else None
+            )
+            projections: Optional[FangraphsPitcherStatsModel] = (
+                FangraphsPitcherStatsModel(**projections_dict) if projections_dict else None
+            )
+            pitcher_stats = MtblPitcherStatsModel(
+                current_season=current_season,
+                projections=projections,
+                espn_stats=pitcher_container,
+            )
         return MtblPitcherModel(**base_data, stats=pitcher_stats)
 
 
@@ -925,12 +948,14 @@ def apply_matches(results: List[PlayerMatchResult]) -> Dict[str, List]:
         # Handle ambiguous matches
         if result.confidence == MatchConfidence.AMBIGUOUS:
             stats_dict = _build_stats_dict(result, is_matched=False)
+            projections_dict: Dict[str, Any] = {}
             espn_stats_container: Optional[Any] = (
                 result.espn_player.stats if result.espn_player.stats else None
             )
             ambiguous_player: MtblPlayerModel = _create_player_model(
                 base_player=base_player,
                 stats_dict=stats_dict,
+                projections_dict=projections_dict,
                 espn_stats_container=espn_stats_container,
                 is_batter=is_batter,
             )
@@ -944,8 +969,12 @@ def apply_matches(results: List[PlayerMatchResult]) -> Dict[str, List]:
         if is_matched:
             base_player.merge_fangraphs_data(result.fangraphs_match)
 
-        # Build combined stats dictionary
+        # Build combined current-season stats dictionary
         stats_dict: Dict[str, Any] = _build_stats_dict(result, is_matched)
+
+        projections_dict: Dict[str, Any] = (
+            _extract_fangraphs_projections(result.fangraphs_match) if is_matched else {}
+        )
 
         # Extract ESPN stats container
         espn_stats_container: Optional[Any] = (
@@ -956,6 +985,7 @@ def apply_matches(results: List[PlayerMatchResult]) -> Dict[str, List]:
         player_model: MtblPlayerModel = _create_player_model(
             base_player=base_player,
             stats_dict=stats_dict,
+            projections_dict=projections_dict,
             espn_stats_container=espn_stats_container,
             is_batter=is_batter,
         )

--- a/player_universe_trx/models/mtbl/__init__.py
+++ b/player_universe_trx/models/mtbl/__init__.py
@@ -4,7 +4,9 @@ from player_universe_trx.models.mtbl.batter import MtblBatterModel
 from player_universe_trx.models.mtbl.mtbl_player import MtblPlayerModel
 from player_universe_trx.models.mtbl.pitcher import MtblPitcherModel
 from player_universe_trx.models.mtbl.stats import (
+    MtblBatterSeasonStatsModel,
     MtblBatterStatsModel,
+    MtblPitcherSeasonStatsModel,
     MtblPitcherStatsModel,
 )
 
@@ -12,6 +14,8 @@ __all__ = [
     "MtblPlayerModel",
     "MtblBatterModel",
     "MtblPitcherModel",
+    "MtblBatterSeasonStatsModel",
     "MtblBatterStatsModel",
+    "MtblPitcherSeasonStatsModel",
     "MtblPitcherStatsModel",
 ]

--- a/player_universe_trx/models/mtbl/stats.py
+++ b/player_universe_trx/models/mtbl/stats.py
@@ -6,13 +6,17 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from player_universe_trx.models.espn.batter import EspnBatterStats
 from player_universe_trx.models.espn.pitcher import EspnPitcherStats
+from player_universe_trx.models.fangraphs.stats import (
+    FangraphsBatterStatsModel,
+    FangraphsPitcherStatsModel,
+)
 
 
-class MtblBatterStatsModel(BaseModel):
+class MtblBatterSeasonStatsModel(BaseModel):
     """
-    MTBL batter statistics combining ESPN current stats, FanGraphs projections, and Savant sabermetrics.
+    MTBL batter stats for the current season, including projections and sabermetrics.
 
-    This model holds all three stat types in a single object since each source provides unique data:
+    This model holds all stat types in a single object since each source provides unique data:
     - ESPN: Current season statistics (actual performance)
     - FanGraphs: Projections (expected future performance)
     - Savant: Sabermetrics (advanced metrics like exit velocity, barrel rate, etc.)
@@ -56,56 +60,6 @@ class MtblBatterStatsModel(BaseModel):
     GDP: Optional[float] = Field(default=None, description="Grounded Into Double Play (ESPN)")
     B_SO: Optional[float] = Field(default=None, description="Strikeouts (ESPN)")
     G: Optional[float] = Field(default=None, description="Games (ESPN)")
-
-    # ========== FanGraphs Projections ==========
-    # Counting stats
-    proj_pa: Optional[float] = Field(default=None, description="Projected Plate Appearances (FG)")
-    proj_ab: Optional[float] = Field(default=None, description="Projected At Bats (FG)")
-    proj_h: Optional[float] = Field(default=None, description="Projected Hits (FG)")
-    proj_singles: Optional[float] = Field(default=None, description="Projected Singles (FG)")
-    proj_doubles: Optional[float] = Field(default=None, description="Projected Doubles (FG)")
-    proj_triples: Optional[float] = Field(default=None, description="Projected Triples (FG)")
-    proj_hr: Optional[float] = Field(default=None, description="Projected Home Runs (FG)")
-    proj_r: Optional[float] = Field(default=None, description="Projected Runs (FG)")
-    proj_rbi: Optional[float] = Field(default=None, description="Projected RBIs (FG)")
-    proj_bb: Optional[float] = Field(default=None, description="Projected Walks (FG)")
-    proj_ibb: Optional[float] = Field(default=None, description="Projected Intentional Walks (FG)")
-    proj_so: Optional[float] = Field(default=None, description="Projected Strikeouts (FG)")
-    proj_hbp: Optional[float] = Field(default=None, description="Projected Hit By Pitch (FG)")
-    proj_sf: Optional[float] = Field(default=None, description="Projected Sacrifice Flies (FG)")
-    proj_sh: Optional[float] = Field(default=None, description="Projected Sacrifice Hits (FG)")
-    proj_sb: Optional[float] = Field(default=None, description="Projected Stolen Bases (FG)")
-    proj_cs: Optional[float] = Field(default=None, description="Projected Caught Stealing (FG)")
-
-    # Rate stats
-    proj_avg: Optional[float] = Field(default=None, description="Projected Batting Average (FG)")
-    proj_obp: Optional[float] = Field(default=None, description="Projected On-Base Percentage (FG)")
-    proj_slg: Optional[float] = Field(default=None, description="Projected Slugging (FG)")
-    proj_ops: Optional[float] = Field(default=None, description="Projected OPS (FG)")
-    proj_iso: Optional[float] = Field(default=None, description="Projected Isolated Power (FG)")
-    proj_woba: Optional[float] = Field(default=None, description="Projected wOBA (FG)")
-    proj_wrc_plus: Optional[float] = Field(default=None, description="Projected wRC+ (FG)")
-    proj_bb_k: Optional[float] = Field(default=None, description="Projected BB/K (FG)")
-
-    # Advanced metrics
-    proj_w_bsr: Optional[float] = Field(default=None, description="Projected Weighted Base Running (FG)")
-    proj_spd: Optional[float] = Field(default=None, description="Projected Speed Score (FG)")
-    proj_wraa: Optional[float] = Field(default=None, description="Projected wRAA (FG)")
-    proj_wrc: Optional[float] = Field(default=None, description="Projected wRC (FG)")
-    proj_ubr: Optional[float] = Field(default=None, description="Projected UBR (FG)")
-    proj_off: Optional[float] = Field(default=None, description="Projected Offensive Value (FG)")
-    proj_def: Optional[float] = Field(default=None, description="Projected Defensive Value (FG)")
-    proj_uzr: Optional[float] = Field(default=None, description="Projected UZR (FG)")
-    proj_base_running: Optional[float] = Field(default=None, description="Projected Base Running Value (FG)")
-
-    # Fantasy and uncertainty metrics
-    proj_fpts_g: Optional[float] = Field(default=None, description="Projected Fantasy Pts/G (FG)")
-    proj_spts_g: Optional[float] = Field(default=None, description="Projected Standard Pts/G (FG)")
-    proj_woba_sd: Optional[float] = Field(default=None, description="Projected wOBA SD (FG)")
-    proj_truetalent_sd: Optional[float] = Field(default=None, description="Projected True Talent SD (FG)")
-    proj_woba_sd_book: Optional[float] = Field(default=None, description="Projected wOBA SD Book (FG)")
-    proj_woba_se: Optional[float] = Field(default=None, description="Projected wOBA SE (FG)")
-    proj_total_se: Optional[float] = Field(default=None, description="Projected Total SE (FG)")
 
     # ========== Savant Sabermetrics ==========
     # Contact metrics
@@ -162,16 +116,36 @@ class MtblBatterStatsModel(BaseModel):
     rate_ideal_attack_angle: Optional[float] = Field(default=None, description="Rate Ideal Attack Angle (Savant)")
     pitch_velo: Optional[float] = Field(default=None, description="Avg Pitch Velocity Faced (Savant)")
 
-    # ========== ESPN Stats Container ==========
-    # Holds all ESPN stat periods: projections, last_7_games, last_15_games, last_30_games, previous_season_24
-    espn_stats: Optional[EspnBatterStats] = Field(default=None, description="ESPN stats container with all periods")
 
-
-class MtblPitcherStatsModel(BaseModel):
+class MtblBatterStatsModel(BaseModel):
     """
-    MTBL pitcher statistics combining ESPN current stats, FanGraphs projections, and Savant sabermetrics.
+    MTBL batter statistics container with current season stats and ESPN periods.
 
-    This model holds all three stat types in a single object since each source provides unique data:
+    Current season stats contain ESPN current season data and Savant sabermetrics, while
+    FanGraphs projections live in the projections object and ESPN historical periods are
+    preserved in espn_stats.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    current_season: Optional[MtblBatterSeasonStatsModel] = Field(
+        default=None,
+        description="Combined current season stats (ESPN current + Savant)",
+    )
+    projections: Optional[FangraphsBatterStatsModel] = Field(
+        default=None,
+        description="FanGraphs projection stats",
+    )
+    espn_stats: Optional[EspnBatterStats] = Field(
+        default=None, description="ESPN stats container with all periods"
+    )
+
+
+class MtblPitcherSeasonStatsModel(BaseModel):
+    """
+    MTBL pitcher stats for the current season, including projections and sabermetrics.
+
+    This model holds all stat types in a single object since each source provides unique data:
     - ESPN: Current season statistics (actual performance)
     - FanGraphs: Projections (expected future performance)
     - Savant: Sabermetrics (advanced metrics like spin rate, velocity, etc.)
@@ -201,48 +175,6 @@ class MtblPitcherStatsModel(BaseModel):
     WPCT: Optional[float] = Field(default=None, description="Win Percentage (ESPN)")
     QS: Optional[float] = Field(default=None, description="Quality Starts (ESPN)")
     k_bb_ratio: Optional[float] = Field(default=None, alias="K/BB", description="K/BB Ratio (ESPN)")
-
-    # ========== FanGraphs Projections ==========
-    # Counting stats
-    proj_wins: Optional[float] = Field(default=None, description="Projected Wins (FG)")
-    proj_losses: Optional[float] = Field(default=None, description="Projected Losses (FG)")
-    proj_games_started: Optional[float] = Field(default=None, description="Projected GS (FG)")
-    proj_saves: Optional[float] = Field(default=None, description="Projected Saves (FG)")
-    proj_holds: Optional[float] = Field(default=None, description="Projected Holds (FG)")
-    proj_innings_pitched: Optional[float] = Field(default=None, description="Projected IP (FG)")
-    proj_total_batters_faced: Optional[float] = Field(default=None, description="Projected TBF (FG)")
-    proj_hits: Optional[float] = Field(default=None, description="Projected Hits Allowed (FG)")
-    proj_runs: Optional[float] = Field(default=None, description="Projected Runs Allowed (FG)")
-    proj_earned_runs: Optional[float] = Field(default=None, description="Projected ER (FG)")
-    proj_home_runs: Optional[float] = Field(default=None, description="Projected HR Allowed (FG)")
-    proj_strikeouts: Optional[float] = Field(default=None, description="Projected Strikeouts (FG)")
-    proj_walks: Optional[float] = Field(default=None, description="Projected Walks (FG)")
-    proj_intentional_walks: Optional[float] = Field(default=None, description="Projected IBB (FG)")
-    proj_hit_by_pitch: Optional[float] = Field(default=None, description="Projected HBP (FG)")
-    proj_quality_starts: Optional[float] = Field(default=None, description="Projected QS (FG)")
-
-    # Rate stats
-    proj_era: Optional[float] = Field(default=None, description="Projected ERA (FG)")
-    proj_whip: Optional[float] = Field(default=None, description="Projected WHIP (FG)")
-    proj_k_per_9: Optional[float] = Field(default=None, description="Projected K/9 (FG)")
-    proj_bb_per_9: Optional[float] = Field(default=None, description="Projected BB/9 (FG)")
-    proj_k_per_bb: Optional[float] = Field(default=None, description="Projected K/BB (FG)")
-    proj_hr_per_9: Optional[float] = Field(default=None, description="Projected HR/9 (FG)")
-    proj_k_bb_percent: Optional[float] = Field(default=None, description="Projected K-BB% (FG)")
-    proj_gb_percent: Optional[float] = Field(default=None, description="Projected GB% (FG)")
-    proj_avg_against: Optional[float] = Field(default=None, description="Projected AVG Against (FG)")
-    proj_lob_percent: Optional[float] = Field(default=None, description="Projected LOB% (FG)")
-
-    # Advanced metrics
-    proj_fip: Optional[float] = Field(default=None, description="Projected FIP (FG)")
-    proj_ra9_war: Optional[float] = Field(default=None, description="Projected RA9-WAR (FG)")
-
-    # Fantasy and uncertainty metrics
-    proj_fpts_ip: Optional[float] = Field(default=None, description="Projected Fantasy Pts/IP (FG)")
-    proj_spts_ip: Optional[float] = Field(default=None, description="Projected Standard Pts/IP (FG)")
-    proj_ra_talent_sd: Optional[float] = Field(default=None, description="Projected RA Talent SD (FG)")
-    proj_chance_ra_se: Optional[float] = Field(default=None, description="Projected Chance RA SE (FG)")
-    proj_total_ra_se: Optional[float] = Field(default=None, description="Projected Total RA SE (FG)")
 
     # ========== Savant Sabermetrics ==========
     # Pitch characteristics
@@ -303,6 +235,26 @@ class MtblPitcherStatsModel(BaseModel):
     barrels_total: Optional[int] = Field(default=None, description="Barrels Allowed (Savant)")
     rate_ideal_attack_angle: Optional[float] = Field(default=None, description="Rate Ideal Attack Angle (Savant)")
 
-    # ========== ESPN Stats Container ==========
-    # Holds all ESPN stat periods: projections, last_7_games, last_15_games, last_30_games, previous_season_24
-    espn_stats: Optional[EspnPitcherStats] = Field(default=None, description="ESPN stats container with all periods")
+
+class MtblPitcherStatsModel(BaseModel):
+    """
+    MTBL pitcher statistics container with current season stats and ESPN periods.
+
+    Current season stats contain ESPN current season data and Savant sabermetrics, while
+    FanGraphs projections live in the projections object and ESPN historical periods are
+    preserved in espn_stats.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    current_season: Optional[MtblPitcherSeasonStatsModel] = Field(
+        default=None,
+        description="Combined current season stats (ESPN current + Savant)",
+    )
+    projections: Optional[FangraphsPitcherStatsModel] = Field(
+        default=None,
+        description="FanGraphs projection stats",
+    )
+    espn_stats: Optional[EspnPitcherStats] = Field(
+        default=None, description="ESPN stats container with all periods"
+    )

--- a/tests/matchers/test_espn_stats_handling.py
+++ b/tests/matchers/test_espn_stats_handling.py
@@ -1,7 +1,7 @@
 """Tests for ESPN stats handling in apply_matches function.
 
 These tests verify that ESPN stats are correctly structured:
-- current_season stats are unprefixed at top level
+- current_season stats live under stats.current_season
 - ESPN stats container is nested under espn_stats field
 - All ESPN periods are preserved (projections, last_7/15/30_games, previous_season_24)
 """
@@ -21,7 +21,7 @@ from player_universe_trx.models.savant.pitcher import SavantPitcherStatsModel
 # ========== Basic Tests - Current Season Only ==========
 
 def test_espn_batter_current_season_only():
-    """Test that ESPN current_season stats are unprefixed at top level."""
+    """Test that ESPN current_season stats are stored under stats.current_season."""
     espn_player = EspnBatterModel(
         id=1,
         name="Aaron Judge",
@@ -56,12 +56,12 @@ def test_espn_batter_current_season_only():
     assert len(matched) == 1
 
     player = matched[0]
-    # Verify current season stats are at top level (unprefixed)
-    assert player.stats.AB == 500
-    assert player.stats.H == 150
-    assert player.stats.HR == 30
-    assert player.stats.RBI == 85
-    assert player.stats.AVG == 0.300
+    # Verify current season stats are nested under current_season
+    assert player.stats.current_season.AB == 500
+    assert player.stats.current_season.H == 150
+    assert player.stats.current_season.HR == 30
+    assert player.stats.current_season.RBI == 85
+    assert player.stats.current_season.AVG == 0.300
 
 
 def test_espn_batter_with_nested_container():
@@ -116,7 +116,7 @@ def test_espn_batter_with_nested_container():
 
 
 def test_espn_batter_both_current_and_nested():
-    """Test that both top-level current stats and nested container work together."""
+    """Test that both current season stats and nested container work together."""
     espn_player = EspnBatterModel(
         id=1,
         name="Aaron Judge",
@@ -145,9 +145,9 @@ def test_espn_batter_both_current_and_nested():
     matched = mtbl_players["matched"]
     player = matched[0]
 
-    # Top-level current season stats
-    assert player.stats.AB == 500
-    assert player.stats.HR == 30
+    # Current season stats
+    assert player.stats.current_season.AB == 500
+    assert player.stats.current_season.HR == 30
 
     # Nested container with projections
     assert player.stats.espn_stats.projections.AB == 550
@@ -159,7 +159,7 @@ def test_espn_batter_both_current_and_nested():
 
 
 def test_espn_pitcher_current_season_only():
-    """Test that ESPN pitcher current_season stats are unprefixed at top level."""
+    """Test that ESPN pitcher current_season stats are stored under stats.current_season."""
     espn_player = EspnPitcherModel(
         id=1,
         name="Gerrit Cole",
@@ -194,12 +194,12 @@ def test_espn_pitcher_current_season_only():
     assert len(matched) == 1
 
     player = matched[0]
-    # Verify current season stats are at top level (unprefixed)
-    assert player.stats.W == 15
-    assert player.stats.L == 6
-    assert player.stats.ERA == 3.15
-    assert player.stats.WHIP == 1.08
-    assert player.stats.K == 215
+    # Verify current season stats are nested under current_season
+    assert player.stats.current_season.W == 15
+    assert player.stats.current_season.L == 6
+    assert player.stats.current_season.ERA == 3.15
+    assert player.stats.current_season.WHIP == 1.08
+    assert player.stats.current_season.K == 215
 
 
 def test_espn_pitcher_with_nested_container():
@@ -249,7 +249,7 @@ def test_espn_pitcher_with_nested_container():
 
 
 def test_espn_pitcher_both_current_and_nested():
-    """Test that pitcher top-level current stats and nested container work together."""
+    """Test that pitcher current season stats and nested container work together."""
     espn_player = EspnPitcherModel(
         id=1,
         name="Gerrit Cole",
@@ -278,9 +278,9 @@ def test_espn_pitcher_both_current_and_nested():
     matched = mtbl_players["matched"]
     player = matched[0]
 
-    # Top-level current season stats
-    assert player.stats.W == 15
-    assert player.stats.ERA == 3.15
+    # Current season stats
+    assert player.stats.current_season.W == 15
+    assert player.stats.current_season.ERA == 3.15
 
     # Nested container with projections
     assert player.stats.espn_stats.projections.W == 16
@@ -346,19 +346,19 @@ def test_all_sources_batters_matched():
     matched = mtbl_players["matched"]
     player = matched[0]
 
-    # ESPN current season (top level, unprefixed)
-    assert player.stats.AB == 500
-    assert player.stats.HR == 30
-    assert player.stats.RBI == 85
+    # ESPN current season (nested under current_season)
+    assert player.stats.current_season.AB == 500
+    assert player.stats.current_season.HR == 30
+    assert player.stats.current_season.RBI == 85
 
-    # FanGraphs projections (top level, proj_ prefix)
-    assert player.stats.proj_ab == 575
-    assert player.stats.proj_hr == 38
-    assert player.stats.proj_rbi == 100
+    # FanGraphs projections (nested under projections)
+    assert player.stats.projections.ab == 575
+    assert player.stats.projections.hr == 38
+    assert player.stats.projections.rbi == 100
 
-    # Savant (top level, unprefixed)
-    assert player.stats.exit_velo == 95.5
-    assert player.stats.xwOBA == 0.420
+    # Savant (nested under current_season, unprefixed)
+    assert player.stats.current_season.exit_velo == 95.5
+    assert player.stats.current_season.xwOBA == 0.420
 
     # ESPN container (nested)
     assert player.stats.espn_stats.projections.HR == 35
@@ -421,19 +421,19 @@ def test_all_sources_pitchers_matched():
     matched = mtbl_players["matched"]
     player = matched[0]
 
-    # ESPN current season (top level, unprefixed)
-    assert player.stats.W == 15
-    assert player.stats.K == 215
-    assert player.stats.ERA == 3.15
+    # ESPN current season (nested under current_season)
+    assert player.stats.current_season.W == 15
+    assert player.stats.current_season.K == 215
+    assert player.stats.current_season.ERA == 3.15
 
-    # FanGraphs projections (top level, proj_ prefix)
-    assert player.stats.proj_wins == 17
-    assert player.stats.proj_strikeouts == 230
-    assert player.stats.proj_era == 3.00
+    # FanGraphs projections (nested under projections)
+    assert player.stats.projections.wins == 17
+    assert player.stats.projections.strikeouts == 230
+    assert player.stats.projections.era == 3.00
 
-    # Savant (top level, unprefixed)
-    assert player.stats.velo == 97.2
-    assert player.stats.swing_miss_pct == 32.5
+    # Savant (nested under current_season, unprefixed)
+    assert player.stats.current_season.velo == 97.2
+    assert player.stats.current_season.swing_miss_pct == 32.5
 
     # ESPN container (nested)
     assert player.stats.espn_stats.projections.W == 16
@@ -463,9 +463,9 @@ def test_espn_stats_unmatched_players():
     assert len(unmatched) == 1
 
     player = unmatched[0]
-    # Current season at top level
-    assert player.stats.AB == 100
-    assert player.stats.HR == 5
+    # Current season under current_season
+    assert player.stats.current_season.AB == 100
+    assert player.stats.current_season.HR == 5
 
     # ESPN container nested
     assert player.stats.espn_stats.projections.AB == 400
@@ -584,5 +584,5 @@ def test_access_nested_espn_projections():
     assert player.stats.espn_stats.last_7_games.AVG == 0.357
     assert player.stats.espn_stats.previous_season_24.AVG == 0.285
 
-    # Top level should have current season
-    assert player.stats.AVG == 0.300
+    # Current season should be nested under current_season
+    assert player.stats.current_season.AVG == 0.300

--- a/tests/matchers/test_player_matcher_coverage.py
+++ b/tests/matchers/test_player_matcher_coverage.py
@@ -478,9 +478,9 @@ def test_apply_matches_espn_stats_batters_matched():
 
     matched = mtbl_players["matched"]
     assert len(matched) == 1
-    # Verify ESPN current season stats are at top level
-    assert matched[0].stats.AB == 500
-    assert matched[0].stats.HR == 30
+    # Verify ESPN current season stats are nested under current_season
+    assert matched[0].stats.current_season.AB == 500
+    assert matched[0].stats.current_season.HR == 30
 
 
 def test_apply_matches_espn_stats_pitchers_matched():
@@ -513,9 +513,9 @@ def test_apply_matches_espn_stats_pitchers_matched():
 
     matched = mtbl_players["matched"]
     assert len(matched) == 1
-    # Verify ESPN current season stats are at top level
-    assert matched[0].stats.W == 15
-    assert matched[0].stats.K == 215
+    # Verify ESPN current season stats are nested under current_season
+    assert matched[0].stats.current_season.W == 15
+    assert matched[0].stats.current_season.K == 215
 
 
 def test_apply_matches_espn_stats_batters_unmatched():
@@ -540,9 +540,9 @@ def test_apply_matches_espn_stats_batters_unmatched():
 
     unmatched = mtbl_players["unmatched"]
     assert len(unmatched) == 1
-    # Verify ESPN current season stats are at top level
-    assert unmatched[0].stats.AB == 100
-    assert unmatched[0].stats.HR == 5
+    # Verify ESPN current season stats are nested under current_season
+    assert unmatched[0].stats.current_season.AB == 100
+    assert unmatched[0].stats.current_season.HR == 5
 
 
 def test_apply_matches_espn_stats_pitchers_unmatched():
@@ -567,6 +567,6 @@ def test_apply_matches_espn_stats_pitchers_unmatched():
 
     unmatched = mtbl_players["unmatched"]
     assert len(unmatched) == 1
-    # Verify ESPN current season stats are at top level
-    assert unmatched[0].stats.W == 5
-    assert unmatched[0].stats.K == 50
+    # Verify ESPN current season stats are nested under current_season
+    assert unmatched[0].stats.current_season.W == 5
+    assert unmatched[0].stats.current_season.K == 50

--- a/tests/matchers/test_savant_matching.py
+++ b/tests/matchers/test_savant_matching.py
@@ -195,15 +195,16 @@ def test_savant_stats_merged_correctly():
 
     # Verify Savant stats were merged into stats object
     assert matched_player.stats is not None
-    assert matched_player.stats.exit_velo == 95.4
-    assert matched_player.stats.barrels_per_bbe_pct == 15.2
-    assert matched_player.stats.hardhit_pct == 52.3
-    assert matched_player.stats.xwOBA == 0.463
-    assert matched_player.stats.xAVG == 0.312
-    assert matched_player.stats.xSLG == 0.654
-    assert matched_player.stats.swing_miss_pct == 22.5
-    assert matched_player.stats.bat_speed == 75.8
-    assert matched_player.stats.attack_angle == 12.3
+    assert matched_player.stats.current_season is not None
+    assert matched_player.stats.current_season.exit_velo == 95.4
+    assert matched_player.stats.current_season.barrels_per_bbe_pct == 15.2
+    assert matched_player.stats.current_season.hardhit_pct == 52.3
+    assert matched_player.stats.current_season.xwOBA == 0.463
+    assert matched_player.stats.current_season.xAVG == 0.312
+    assert matched_player.stats.current_season.xSLG == 0.654
+    assert matched_player.stats.current_season.swing_miss_pct == 22.5
+    assert matched_player.stats.current_season.bat_speed == 75.8
+    assert matched_player.stats.current_season.attack_angle == 12.3
 
 
 def test_savant_no_data_when_no_fangraphs_match():

--- a/tests/models/mtbl/test_batter_stats.py
+++ b/tests/models/mtbl/test_batter_stats.py
@@ -2,369 +2,412 @@
 
 import pytest
 
-from player_universe_trx.models.mtbl import MtblBatterStatsModel
+from player_universe_trx.models.fangraphs.stats import FangraphsBatterStatsModel
+from player_universe_trx.models.mtbl import (
+    MtblBatterSeasonStatsModel,
+    MtblBatterStatsModel,
+)
 
 
 def test_batter_stats_model_creation_empty():
     """Test creating an empty batter stats model."""
     stats = MtblBatterStatsModel()
     assert stats is not None
-    assert stats.AB is None
-    assert stats.proj_hr is None
-    assert stats.exit_velo is None
+    assert stats.current_season is None
+    assert stats.espn_stats is None
 
 
 def test_batter_stats_espn_only():
     """Test batter stats with only ESPN current season data."""
     stats = MtblBatterStatsModel(
-        AB=500,
-        H=150,
-        AVG=0.300,
-        HR=30,
-        RBI=100,
-        R=85,
-        SB=15,
-        OBP=0.375,
-        SLG=0.550,
-        OPS=0.925
+        current_season=MtblBatterSeasonStatsModel(
+            AB=500,
+            H=150,
+            AVG=0.300,
+            HR=30,
+            RBI=100,
+            R=85,
+            SB=15,
+            OBP=0.375,
+            SLG=0.550,
+            OPS=0.925,
+        )
     )
 
+    assert stats.current_season is not None
+
     # ESPN stats should be populated
-    assert stats.AB == 500
-    assert stats.H == 150
-    assert stats.AVG == 0.300
-    assert stats.HR == 30
-    assert stats.RBI == 100
-    assert stats.R == 85
-    assert stats.SB == 15
-    assert stats.OBP == 0.375
-    assert stats.SLG == 0.550
-    assert stats.OPS == 0.925
+    assert stats.current_season.AB == 500
+    assert stats.current_season.H == 150
+    assert stats.current_season.AVG == 0.300
+    assert stats.current_season.HR == 30
+    assert stats.current_season.RBI == 100
+    assert stats.current_season.R == 85
+    assert stats.current_season.SB == 15
+    assert stats.current_season.OBP == 0.375
+    assert stats.current_season.SLG == 0.550
+    assert stats.current_season.OPS == 0.925
 
     # FanGraphs and Savant should be None
-    assert stats.proj_hr is None
-    assert stats.exit_velo is None
+    assert stats.projections is None
+    assert stats.current_season.exit_velo is None
 
 
 def test_batter_stats_fangraphs_projections_only():
     """Test batter stats with only FanGraphs projection data."""
     stats = MtblBatterStatsModel(
-        proj_ab=550,
-        proj_h=165,
-        proj_avg=0.300,
-        proj_hr=32,
-        proj_rbi=95,
-        proj_r=90,
-        proj_sb=12,
-        proj_obp=0.370,
-        proj_slg=0.540,
-        proj_ops=0.910,
-        proj_woba=0.380,
-        proj_wrc_plus=125.5
+        projections=FangraphsBatterStatsModel(
+            ab=550,
+            h=165,
+            avg=0.300,
+            hr=32,
+            rbi=95,
+            r=90,
+            sb=12,
+            obp=0.370,
+            slg=0.540,
+            ops=0.910,
+            woba=0.380,
+            wrc_plus=125.5,
+        )
     )
 
     # FanGraphs projections should be populated
-    assert stats.proj_ab == 550
-    assert stats.proj_h == 165
-    assert stats.proj_avg == 0.300
-    assert stats.proj_hr == 32
-    assert stats.proj_rbi == 95
-    assert stats.proj_r == 90
-    assert stats.proj_sb == 12
-    assert stats.proj_obp == 0.370
-    assert stats.proj_slg == 0.540
-    assert stats.proj_ops == 0.910
-    assert stats.proj_woba == 0.380
-    assert stats.proj_wrc_plus == 125.5
+    assert stats.projections is not None
+    assert stats.projections.ab == 550
+    assert stats.projections.h == 165
+    assert stats.projections.avg == 0.300
+    assert stats.projections.hr == 32
+    assert stats.projections.rbi == 95
+    assert stats.projections.r == 90
+    assert stats.projections.sb == 12
+    assert stats.projections.obp == 0.370
+    assert stats.projections.slg == 0.540
+    assert stats.projections.ops == 0.910
+    assert stats.projections.woba == 0.380
+    assert stats.projections.wrc_plus == 125.5
 
     # ESPN and Savant should be None
-    assert stats.AB is None
-    assert stats.exit_velo is None
+    assert stats.current_season is None
 
 
 def test_batter_stats_savant_sabermetrics_only():
     """Test batter stats with only Savant sabermetric data."""
     stats = MtblBatterStatsModel(
-        exit_velo=92.5,
-        launch_angle=15.2,
-        barrel_rate=12.5,
-        barrels_per_bbe_pct=12.5,
-        hard_hit_rate=45.8,
-        hardhit_pct=45.8,
-        xwoba=0.380,
-        xavg=0.295,
-        xslg=0.520,
-        xwOBA=0.380,
-        xAVG=0.295,
-        xSLG=0.520,
-        swing_miss_pct=24.5,
-        bat_speed=72.3,
-        attack_angle=14.8
+        current_season=MtblBatterSeasonStatsModel(
+            exit_velo=92.5,
+            launch_angle=15.2,
+            barrel_rate=12.5,
+            barrels_per_bbe_pct=12.5,
+            hard_hit_rate=45.8,
+            hardhit_pct=45.8,
+            xwoba=0.380,
+            xavg=0.295,
+            xslg=0.520,
+            xwOBA=0.380,
+            xAVG=0.295,
+            xSLG=0.520,
+            swing_miss_pct=24.5,
+            bat_speed=72.3,
+            attack_angle=14.8,
+        )
     )
 
+    assert stats.current_season is not None
+
     # Savant sabermetrics should be populated
-    assert stats.exit_velo == 92.5
-    assert stats.launch_angle == 15.2
-    assert stats.barrel_rate == 12.5
-    assert stats.barrels_per_bbe_pct == 12.5
-    assert stats.hard_hit_rate == 45.8
-    assert stats.hardhit_pct == 45.8
-    assert stats.xwoba == 0.380
-    assert stats.xavg == 0.295
-    assert stats.xslg == 0.520
-    assert stats.xwOBA == 0.380
-    assert stats.xAVG == 0.295
-    assert stats.xSLG == 0.520
-    assert stats.swing_miss_pct == 24.5
-    assert stats.bat_speed == 72.3
-    assert stats.attack_angle == 14.8
+    assert stats.current_season.exit_velo == 92.5
+    assert stats.current_season.launch_angle == 15.2
+    assert stats.current_season.barrel_rate == 12.5
+    assert stats.current_season.barrels_per_bbe_pct == 12.5
+    assert stats.current_season.hard_hit_rate == 45.8
+    assert stats.current_season.hardhit_pct == 45.8
+    assert stats.current_season.xwoba == 0.380
+    assert stats.current_season.xavg == 0.295
+    assert stats.current_season.xslg == 0.520
+    assert stats.current_season.xwOBA == 0.380
+    assert stats.current_season.xAVG == 0.295
+    assert stats.current_season.xSLG == 0.520
+    assert stats.current_season.swing_miss_pct == 24.5
+    assert stats.current_season.bat_speed == 72.3
+    assert stats.current_season.attack_angle == 14.8
 
     # ESPN and FanGraphs should be None
-    assert stats.AB is None
-    assert stats.proj_hr is None
+    assert stats.current_season.AB is None
+    assert stats.projections is None
 
 
 def test_batter_stats_all_sources_combined():
     """Test batter stats with data from all three sources combined."""
     stats = MtblBatterStatsModel(
-        # ESPN current season
-        AB=520,
-        H=156,
-        AVG=0.300,
-        HR=32,
-        RBI=98,
-        R=88,
-        SB=18,
-        CS=4,
-        OBP=0.378,
-        SLG=0.545,
-        OPS=0.923,
+        current_season=MtblBatterSeasonStatsModel(
+            # ESPN current season
+            AB=520,
+            H=156,
+            AVG=0.300,
+            HR=32,
+            RBI=98,
+            R=88,
+            SB=18,
+            CS=4,
+            OBP=0.378,
+            SLG=0.545,
+            OPS=0.923,
 
-        # FanGraphs projections
-        proj_ab=540,
-        proj_h=162,
-        proj_avg=0.300,
-        proj_hr=30,
-        proj_rbi=95,
-        proj_r=90,
-        proj_sb=15,
-        proj_obp=0.375,
-        proj_slg=0.540,
-        proj_ops=0.915,
-        proj_woba=0.375,
-        proj_wrc_plus=128.0,
-
-        # Savant sabermetrics
-        exit_velo=93.2,
-        launch_angle=14.5,
-        barrel_rate=13.2,
-        barrels_per_bbe_pct=13.2,
-        hard_hit_rate=47.5,
-        hardhit_pct=47.5,
-        xwoba=0.385,
-        xavg=0.298,
-        xslg=0.530,
-        xwOBA=0.385,
-        xAVG=0.298,
-        xSLG=0.530,
-        swing_miss_pct=23.8,
-        bat_speed=73.1,
-        attack_angle=15.2
+            # Savant sabermetrics
+            exit_velo=93.2,
+            launch_angle=14.5,
+            barrel_rate=13.2,
+            barrels_per_bbe_pct=13.2,
+            hard_hit_rate=47.5,
+            hardhit_pct=47.5,
+            xwoba=0.385,
+            xavg=0.298,
+            xslg=0.530,
+            xwOBA=0.385,
+            xAVG=0.298,
+            xSLG=0.530,
+            swing_miss_pct=23.8,
+            bat_speed=73.1,
+            attack_angle=15.2,
+        ),
+        projections=FangraphsBatterStatsModel(
+            ab=540,
+            h=162,
+            avg=0.300,
+            hr=30,
+            rbi=95,
+            r=90,
+            sb=15,
+            obp=0.375,
+            slg=0.540,
+            ops=0.915,
+            woba=0.375,
+            wrc_plus=128.0,
+        ),
     )
 
+    assert stats.current_season is not None
+
     # Verify ESPN stats
-    assert stats.AB == 520
-    assert stats.AVG == 0.300
-    assert stats.HR == 32
-    assert stats.OPS == 0.923
+    assert stats.current_season.AB == 520
+    assert stats.current_season.AVG == 0.300
+    assert stats.current_season.HR == 32
+    assert stats.current_season.OPS == 0.923
 
     # Verify FanGraphs projections
-    assert stats.proj_ab == 540
-    assert stats.proj_avg == 0.300
-    assert stats.proj_hr == 30
-    assert stats.proj_wrc_plus == 128.0
+    assert stats.projections.ab == 540
+    assert stats.projections.avg == 0.300
+    assert stats.projections.hr == 30
+    assert stats.projections.wrc_plus == 128.0
 
     # Verify Savant sabermetrics
-    assert stats.exit_velo == 93.2
-    assert stats.barrel_rate == 13.2
-    assert stats.xwOBA == 0.385
-    assert stats.bat_speed == 73.1
+    assert stats.current_season.exit_velo == 93.2
+    assert stats.current_season.barrel_rate == 13.2
+    assert stats.current_season.xwOBA == 0.385
+    assert stats.current_season.bat_speed == 73.1
 
 
 def test_batter_stats_partial_data_from_each_source():
     """Test batter stats with partial data from each source."""
     stats = MtblBatterStatsModel(
-        # Partial ESPN
-        AB=450,
-        HR=25,
+        current_season=MtblBatterSeasonStatsModel(
+            # Partial ESPN
+            AB=450,
+            HR=25,
 
-        # Partial FanGraphs
-        proj_hr=28,
-        proj_woba=0.360,
-
-        # Partial Savant
-        exit_velo=91.0,
-        barrel_rate=10.5
+            # Partial Savant
+            exit_velo=91.0,
+            barrel_rate=10.5,
+        ),
+        projections=FangraphsBatterStatsModel(
+            hr=28,
+            woba=0.360,
+        ),
     )
 
+    assert stats.current_season is not None
+
     # Verify provided ESPN stats
-    assert stats.AB == 450
-    assert stats.HR == 25
-    assert stats.AVG is None  # Not provided
+    assert stats.current_season.AB == 450
+    assert stats.current_season.HR == 25
+    assert stats.current_season.AVG is None  # Not provided
 
     # Verify provided FanGraphs stats
-    assert stats.proj_hr == 28
-    assert stats.proj_woba == 0.360
-    assert stats.proj_avg is None  # Not provided
+    assert stats.projections.hr == 28
+    assert stats.projections.woba == 0.360
+    assert stats.projections.avg is None  # Not provided
 
     # Verify provided Savant stats
-    assert stats.exit_velo == 91.0
-    assert stats.barrel_rate == 10.5
-    assert stats.xwOBA is None  # Not provided
+    assert stats.current_season.exit_velo == 91.0
+    assert stats.current_season.barrel_rate == 10.5
+    assert stats.current_season.xwOBA is None  # Not provided
 
 
 def test_batter_stats_expected_vs_actual_comparison():
     """Test that we can compare expected (xStats) vs actual performance."""
     stats = MtblBatterStatsModel(
-        # Actual (ESPN)
-        AVG=0.275,
-        SLG=0.480,
+        current_season=MtblBatterSeasonStatsModel(
+            # Actual (ESPN)
+            AVG=0.275,
+            SLG=0.480,
 
-        # Expected (Savant)
-        xAVG=0.290,
-        xSLG=0.510,
-        xAVGdiff=0.015,
-        xSLGdiff=0.030
+            # Expected (Savant)
+            xAVG=0.290,
+            xSLG=0.510,
+            xAVGdiff=0.015,
+            xSLGdiff=0.030,
+        )
     )
 
-    # Verify we can track both actual and expected
-    assert stats.AVG == 0.275
-    assert stats.xAVG == 0.290
-    assert stats.xAVGdiff == 0.015
+    assert stats.current_season is not None
 
-    assert stats.SLG == 0.480
-    assert stats.xSLG == 0.510
-    assert stats.xSLGdiff == 0.030
+    # Verify we can track both actual and expected
+    assert stats.current_season.AVG == 0.275
+    assert stats.current_season.xAVG == 0.290
+    assert stats.current_season.xAVGdiff == 0.015
+
+    assert stats.current_season.SLG == 0.480
+    assert stats.current_season.xSLG == 0.510
+    assert stats.current_season.xSLGdiff == 0.030
 
 
 def test_batter_stats_current_vs_projected_comparison():
     """Test that we can compare current performance vs projections."""
     stats = MtblBatterStatsModel(
-        # Current (ESPN)
-        HR=15,  # Through half season
-        AB=250,
-
-        # Projected (FanGraphs)
-        proj_hr=32,  # Full season projection
-        proj_ab=520
+        current_season=MtblBatterSeasonStatsModel(
+            # Current (ESPN)
+            HR=15,  # Through half season
+            AB=250,
+        ),
+        projections=FangraphsBatterStatsModel(
+            hr=32,  # Full season projection
+            ab=520,
+        ),
     )
 
+    assert stats.current_season is not None
+
     # Verify we can track both current and projected
-    assert stats.HR == 15
-    assert stats.proj_hr == 32
+    assert stats.current_season.HR == 15
+    assert stats.projections.hr == 32
 
     # Can calculate pace: (15 / 250) * 520 = 31.2 HR pace
-    if stats.AB and stats.AB > 0:
-        pace = (stats.HR / stats.AB) * stats.proj_ab
+    if stats.current_season.AB and stats.current_season.AB > 0:
+        pace = (stats.current_season.HR / stats.current_season.AB) * stats.projections.ab
         assert pace == pytest.approx(31.2, abs=0.1)
 
 
 def test_batter_stats_model_dump():
     """Test that model_dump works correctly with all stats."""
     stats = MtblBatterStatsModel(
-        AB=500,
-        HR=30,
-        proj_hr=28,
-        exit_velo=92.0
+        current_season=MtblBatterSeasonStatsModel(
+            AB=500,
+            HR=30,
+            exit_velo=92.0,
+        ),
+        projections=FangraphsBatterStatsModel(
+            hr=28,
+        ),
     )
 
     dumped = stats.model_dump(exclude_none=True)
 
-    assert dumped["AB"] == 500
-    assert dumped["HR"] == 30
-    assert dumped["proj_hr"] == 28
-    assert dumped["exit_velo"] == 92.0
+    assert dumped["current_season"]["AB"] == 500
+    assert dumped["current_season"]["HR"] == 30
+    assert dumped["current_season"]["exit_velo"] == 92.0
+    assert dumped["projections"]["hr"] == 28
 
     # None values should be excluded
-    assert "AVG" not in dumped
-    assert "proj_avg" not in dumped
-    assert "barrel_rate" not in dumped
+    assert "AVG" not in dumped["current_season"]
+    assert "proj_avg" not in dumped["current_season"]
+    assert "barrel_rate" not in dumped["current_season"]
 
 
 def test_batter_stats_plate_discipline_metrics():
     """Test plate discipline metrics from all sources."""
     stats = MtblBatterStatsModel(
-        # ESPN plate discipline
-        B_BB=65,
-        B_SO=120,
-        PA=550,
+        current_season=MtblBatterSeasonStatsModel(
+            # ESPN plate discipline
+            B_BB=65,
+            B_SO=120,
+            PA=550,
 
-        # FanGraphs plate discipline
-        proj_bb=68,
-        proj_so=115,
-        proj_bb_k=0.59,
-
-        # Savant plate discipline
-        swing_miss_pct=24.5,
-        swings=450,
-        whiffs=110,
-        takes=100
+            # Savant plate discipline
+            swing_miss_pct=24.5,
+            swings=450,
+            whiffs=110,
+            takes=100,
+        ),
+        projections=FangraphsBatterStatsModel(
+            bb=68,
+            so=115,
+            bb_k=0.59,
+        ),
     )
 
+    assert stats.current_season is not None
+
     # ESPN
-    assert stats.B_BB == 65
-    assert stats.B_SO == 120
-    assert stats.PA == 550
+    assert stats.current_season.B_BB == 65
+    assert stats.current_season.B_SO == 120
+    assert stats.current_season.PA == 550
 
     # FanGraphs
-    assert stats.proj_bb == 68
-    assert stats.proj_so == 115
-    assert stats.proj_bb_k == 0.59
+    assert stats.projections.bb == 68
+    assert stats.projections.so == 115
+    assert stats.projections.bb_k == 0.59
 
     # Savant
-    assert stats.swing_miss_pct == 24.5
-    assert stats.swings == 450
-    assert stats.whiffs == 110
-    assert stats.takes == 100
+    assert stats.current_season.swing_miss_pct == 24.5
+    assert stats.current_season.swings == 450
+    assert stats.current_season.whiffs == 110
+    assert stats.current_season.takes == 100
 
 
 def test_batter_stats_contact_quality_metrics():
     """Test contact quality metrics from Savant."""
     stats = MtblBatterStatsModel(
-        exit_velo=94.5,
-        adj_exit_velo=95.2,
-        launch_angle=16.2,
-        barrel_rate=15.8,
-        barrels_per_bbe_pct=15.8,
-        barrels_per_pa_pct=8.2,
-        barrels_total=42,
-        hard_hit_rate=48.9,
-        hardhit_pct=48.9
+        current_season=MtblBatterSeasonStatsModel(
+            exit_velo=94.5,
+            adj_exit_velo=95.2,
+            launch_angle=16.2,
+            barrel_rate=15.8,
+            barrels_per_bbe_pct=15.8,
+            barrels_per_pa_pct=8.2,
+            barrels_total=42,
+            hard_hit_rate=48.9,
+            hardhit_pct=48.9,
+        )
     )
 
-    assert stats.exit_velo == 94.5
-    assert stats.adj_exit_velo == 95.2
-    assert stats.launch_angle == 16.2
-    assert stats.barrel_rate == 15.8
-    assert stats.barrels_per_bbe_pct == 15.8
-    assert stats.barrels_per_pa_pct == 8.2
-    assert stats.barrels_total == 42
-    assert stats.hard_hit_rate == 48.9
-    assert stats.hardhit_pct == 48.9
+    assert stats.current_season is not None
+    assert stats.current_season.exit_velo == 94.5
+    assert stats.current_season.adj_exit_velo == 95.2
+    assert stats.current_season.launch_angle == 16.2
+    assert stats.current_season.barrel_rate == 15.8
+    assert stats.current_season.barrels_per_bbe_pct == 15.8
+    assert stats.current_season.barrels_per_pa_pct == 8.2
+    assert stats.current_season.barrels_total == 42
+    assert stats.current_season.hard_hit_rate == 48.9
+    assert stats.current_season.hardhit_pct == 48.9
 
 
 def test_batter_stats_swing_mechanics():
     """Test swing mechanics from Savant."""
     stats = MtblBatterStatsModel(
-        attack_angle=16.5,
-        attack_dir=2.3,
-        bat_speed=74.2,
-        swing_length=7.1,
-        swing_path_tilt=18.2
+        current_season=MtblBatterSeasonStatsModel(
+            attack_angle=16.5,
+            attack_dir=2.3,
+            bat_speed=74.2,
+            swing_length=7.1,
+            swing_path_tilt=18.2,
+        )
     )
 
-    assert stats.attack_angle == 16.5
-    assert stats.attack_dir == 2.3
-    assert stats.bat_speed == 74.2
-    assert stats.swing_length == 7.1
-    assert stats.swing_path_tilt == 18.2
+    assert stats.current_season is not None
+    assert stats.current_season.attack_angle == 16.5
+    assert stats.current_season.attack_dir == 2.3
+    assert stats.current_season.bat_speed == 74.2
+    assert stats.current_season.swing_length == 7.1
+    assert stats.current_season.swing_path_tilt == 18.2

--- a/tests/models/mtbl/test_pitcher_stats.py
+++ b/tests/models/mtbl/test_pitcher_stats.py
@@ -1,404 +1,446 @@
 """Tests for MtblPitcherStatsModel combining ESPN, FanGraphs, and Savant data."""
 
-from player_universe_trx.models.mtbl import MtblPitcherStatsModel
+import pytest
+
+from player_universe_trx.models.fangraphs.stats import FangraphsPitcherStatsModel
+from player_universe_trx.models.mtbl import (
+    MtblPitcherSeasonStatsModel,
+    MtblPitcherStatsModel,
+)
 
 
 def test_pitcher_stats_model_creation_empty():
     """Test creating an empty pitcher stats model."""
     stats = MtblPitcherStatsModel()
     assert stats is not None
-    assert stats.W is None
-    assert stats.proj_wins is None
-    assert stats.velo is None
+    assert stats.current_season is None
+    assert stats.espn_stats is None
 
 
 def test_pitcher_stats_espn_only():
     """Test pitcher stats with only ESPN current season data."""
     stats = MtblPitcherStatsModel(
-        W=12,
-        L=8,
-        ERA=3.45,
-        WHIP=1.15,
-        GP=28,
-        GS=28,
-        K=195,
-        P_BB=45,
-        P_H=160,
-        P_HR=20,
-        QS=18,
-        WPCT=0.600,
+        current_season=MtblPitcherSeasonStatsModel(
+            W=15,
+            L=6,
+            ERA=3.25,
+            WHIP=1.12,
+            K=180,
+            QS=20,
+        )
     )
 
+    assert stats.current_season is not None
+
     # ESPN stats should be populated
-    assert stats.W == 12
-    assert stats.L == 8
-    assert stats.ERA == 3.45
-    assert stats.WHIP == 1.15
-    assert stats.GP == 28
-    assert stats.GS == 28
-    assert stats.K == 195
-    assert stats.P_BB == 45
-    assert stats.P_H == 160
-    assert stats.P_HR == 20
-    assert stats.QS == 18
-    assert stats.WPCT == 0.600
+    assert stats.current_season.W == 15
+    assert stats.current_season.L == 6
+    assert stats.current_season.ERA == 3.25
+    assert stats.current_season.WHIP == 1.12
+    assert stats.current_season.K == 180
+    assert stats.current_season.QS == 20
 
     # FanGraphs and Savant should be None
-    assert stats.proj_wins is None
-    assert stats.velo is None
+    assert stats.projections is None
+    assert stats.current_season.velo is None
 
 
 def test_pitcher_stats_fangraphs_projections_only():
     """Test pitcher stats with only FanGraphs projection data."""
     stats = MtblPitcherStatsModel(
-        proj_wins=13,
-        proj_losses=7,
-        proj_era=3.35,
-        proj_whip=1.12,
-        proj_innings_pitched=185.0,
-        proj_strikeouts=200,
-        proj_walks=42,
-        proj_hits=155,
-        proj_home_runs=18,
-        proj_saves=0,
-        proj_k_per_9=9.73,
-        proj_bb_per_9=2.05,
-        proj_hr_per_9=0.88,
-        proj_fip=3.25,
-        proj_ra9_war=4.2,
+        projections=FangraphsPitcherStatsModel(
+            wins=16,
+            losses=7,
+            era=3.50,
+            whip=1.18,
+            strikeouts=195,
+            k_per_9=9.5,
+            bb_per_9=2.8,
+            fip=3.60,
+            ra9_war=4.2,
+        )
     )
 
     # FanGraphs projections should be populated
-    assert stats.proj_wins == 13
-    assert stats.proj_losses == 7
-    assert stats.proj_era == 3.35
-    assert stats.proj_whip == 1.12
-    assert stats.proj_innings_pitched == 185.0
-    assert stats.proj_strikeouts == 200
-    assert stats.proj_walks == 42
-    assert stats.proj_hits == 155
-    assert stats.proj_home_runs == 18
-    assert stats.proj_saves == 0
-    assert stats.proj_k_per_9 == 9.73
-    assert stats.proj_bb_per_9 == 2.05
-    assert stats.proj_hr_per_9 == 0.88
-    assert stats.proj_fip == 3.25
-    assert stats.proj_ra9_war == 4.2
+    assert stats.projections is not None
+    assert stats.projections.wins == 16
+    assert stats.projections.losses == 7
+    assert stats.projections.era == 3.50
+    assert stats.projections.whip == 1.18
+    assert stats.projections.strikeouts == 195
+    assert stats.projections.k_per_9 == 9.5
+    assert stats.projections.bb_per_9 == 2.8
+    assert stats.projections.fip == 3.60
+    assert stats.projections.ra9_war == 4.2
 
     # ESPN and Savant should be None
-    assert stats.W is None
-    assert stats.velo is None
+    assert stats.current_season is None
 
 
 def test_pitcher_stats_savant_sabermetrics_only():
     """Test pitcher stats with only Savant sabermetric data."""
     stats = MtblPitcherStatsModel(
-        velo=94.5,
-        spin_rate=2450,
-        swing_miss_pct=28.5,
-        xwoba=0.305,
-        xavg=0.235,
-        xslg=0.395,
-        xwOBA=0.305,
-        xAVG=0.235,
-        xSLG=0.395,
-        exit_velo=88.3,
-        release_extension=6.2,
-        break_z=18.5,
-        break_x_arm_side=12.3,
+        current_season=MtblPitcherSeasonStatsModel(
+            velo=96.5,
+            spin_rate=2450,
+            release_extension=6.5,
+            break_z=15.2,
+            break_x_arm_side=6.8,
+            swing_miss_pct=30.5,
+            xwoba=0.285,
+            xavg=0.215,
+        )
     )
 
+    assert stats.current_season is not None
+
     # Savant sabermetrics should be populated
-    assert stats.velo == 94.5
-    assert stats.spin_rate == 2450
-    assert stats.swing_miss_pct == 28.5
-    assert stats.xwoba == 0.305
-    assert stats.xavg == 0.235
-    assert stats.xslg == 0.395
-    assert stats.xwOBA == 0.305
-    assert stats.xAVG == 0.235
-    assert stats.xSLG == 0.395
-    assert stats.exit_velo == 88.3
-    assert stats.release_extension == 6.2
-    assert stats.break_z == 18.5
-    assert stats.break_x_arm_side == 12.3
+    assert stats.current_season.velo == 96.5
+    assert stats.current_season.spin_rate == 2450
+    assert stats.current_season.release_extension == 6.5
+    assert stats.current_season.break_z == 15.2
+    assert stats.current_season.break_x_arm_side == 6.8
+    assert stats.current_season.swing_miss_pct == 30.5
+    assert stats.current_season.xwoba == 0.285
+    assert stats.current_season.xavg == 0.215
 
     # ESPN and FanGraphs should be None
-    assert stats.W is None
-    assert stats.proj_wins is None
+    assert stats.current_season.W is None
+    assert stats.projections is None
 
 
 def test_pitcher_stats_all_sources_combined():
     """Test pitcher stats with data from all three sources combined."""
     stats = MtblPitcherStatsModel(
-        # ESPN current season
-        W=15,
-        L=6,
-        ERA=3.15,
-        WHIP=1.08,
-        GP=30,
-        GS=30,
-        K=215,
-        P_BB=38,
-        P_H=165,
-        P_HR=18,
-        QS=22,
-        # FanGraphs projections
-        proj_wins=14,
-        proj_losses=7,
-        proj_era=3.25,
-        proj_whip=1.10,
-        proj_innings_pitched=190.0,
-        proj_strikeouts=210,
-        proj_walks=40,
-        proj_fip=3.10,
-        proj_ra9_war=4.5,
-        # Savant sabermetrics
-        velo=95.2,
-        spin_rate=2485,
-        swing_miss_pct=29.8,
-        xwoba=0.298,
-        xavg=0.228,
-        xslg=0.385,
-        xwOBA=0.298,
-        xAVG=0.228,
-        xSLG=0.385,
-        exit_velo=87.8,
-        release_extension=6.3,
+        current_season=MtblPitcherSeasonStatsModel(
+            # ESPN current season
+            W=18,
+            L=7,
+            ERA=2.95,
+            WHIP=1.05,
+            K=210,
+            QS=22,
+
+            # Savant sabermetrics
+            velo=97.2,
+            spin_rate=2500,
+            release_extension=6.8,
+            break_z=16.0,
+            swing_miss_pct=32.0,
+            xwoba=0.280,
+        ),
+        projections=FangraphsPitcherStatsModel(
+            wins=17,
+            era=3.10,
+            strikeouts=200,
+            whip=1.10,
+            fip=3.20,
+            ra9_war=5.0,
+        ),
     )
 
+    assert stats.current_season is not None
+
     # Verify ESPN stats
-    assert stats.W == 15
-    assert stats.ERA == 3.15
-    assert stats.K == 215
-    assert stats.WHIP == 1.08
+    assert stats.current_season.W == 18
+    assert stats.current_season.ERA == 2.95
+    assert stats.current_season.K == 210
+    assert stats.current_season.QS == 22
 
     # Verify FanGraphs projections
-    assert stats.proj_wins == 14
-    assert stats.proj_era == 3.25
-    assert stats.proj_strikeouts == 210
-    assert stats.proj_ra9_war == 4.5
+    assert stats.projections.wins == 17
+    assert stats.projections.era == 3.10
+    assert stats.projections.strikeouts == 200
+    assert stats.projections.ra9_war == 5.0
 
     # Verify Savant sabermetrics
-    assert stats.velo == 95.2
-    assert stats.swing_miss_pct == 29.8
-    assert stats.xwOBA == 0.298
-    assert stats.exit_velo == 87.8
+    assert stats.current_season.velo == 97.2
+    assert stats.current_season.spin_rate == 2500
+    assert stats.current_season.swing_miss_pct == 32.0
+    assert stats.current_season.xwoba == 0.280
 
 
 def test_pitcher_stats_partial_data_from_each_source():
     """Test pitcher stats with partial data from each source."""
     stats = MtblPitcherStatsModel(
-        # Partial ESPN
-        W=10,
-        ERA=3.50,
-        # Partial FanGraphs
-        proj_wins=12,
-        proj_fip=3.25,
-        # Partial Savant
-        velo=93.5,
-        swing_miss_pct=27.5,
+        current_season=MtblPitcherSeasonStatsModel(
+            # Partial ESPN
+            W=12,
+            ERA=3.75,
+
+            # Partial Savant
+            velo=95.0,
+            spin_rate=2400,
+        ),
+        projections=FangraphsPitcherStatsModel(
+            era=3.60,
+            fip=3.70,
+        ),
     )
 
+    assert stats.current_season is not None
+
     # Verify provided ESPN stats
-    assert stats.W == 10
-    assert stats.ERA == 3.50
-    assert stats.K is None  # Not provided
+    assert stats.current_season.W == 12
+    assert stats.current_season.ERA == 3.75
+    assert stats.current_season.WHIP is None  # Not provided
 
     # Verify provided FanGraphs stats
-    assert stats.proj_wins == 12
-    assert stats.proj_fip == 3.25
-    assert stats.proj_era is None  # Not provided
+    assert stats.projections.era == 3.60
+    assert stats.projections.fip == 3.70
+    assert stats.projections.wins is None  # Not provided
 
     # Verify provided Savant stats
-    assert stats.velo == 93.5
-    assert stats.swing_miss_pct == 27.5
-    assert stats.xwOBA is None  # Not provided
+    assert stats.current_season.velo == 95.0
+    assert stats.current_season.spin_rate == 2400
+    assert stats.current_season.swing_miss_pct is None  # Not provided
 
 
 def test_pitcher_stats_expected_vs_actual_comparison():
     """Test that we can compare expected (xStats) vs actual performance."""
     stats = MtblPitcherStatsModel(
-        # Actual (ESPN)
-        ERA=3.80,
-        OBA=0.265,  # Opponent batting average
-        # Expected (Savant)
-        xwOBA=0.310,
-        xAVG=0.240,
-        xSLG=0.395,
-        xAVGdiff=0.025,
-        xSLGdiff=0.030,
+        current_season=MtblPitcherSeasonStatsModel(
+            # Actual (ESPN)
+            ERA=3.50,
+            WHIP=1.15,
+
+            # Expected (Savant)
+            xAVG=0.230,
+            xSLG=0.380,
+            xAVGdiff=0.010,
+            xSLGdiff=0.020,
+        )
     )
 
-    # Verify we can track both actual and expected
-    assert stats.ERA == 3.80
-    assert stats.OBA == 0.265
+    assert stats.current_season is not None
 
-    assert stats.xAVG == 0.240
-    assert stats.xSLG == 0.395
-    assert stats.xAVGdiff == 0.025
-    assert stats.xSLGdiff == 0.030
+    # Verify we can track both actual and expected
+    assert stats.current_season.ERA == 3.50
+    assert stats.current_season.xAVG == 0.230
+    assert stats.current_season.xAVGdiff == 0.010
+
+    assert stats.current_season.WHIP == 1.15
+    assert stats.current_season.xSLG == 0.380
+    assert stats.current_season.xSLGdiff == 0.020
 
 
 def test_pitcher_stats_current_vs_projected_comparison():
     """Test that we can compare current performance vs projections."""
     stats = MtblPitcherStatsModel(
-        # Current (ESPN) - through half season
-        W=8,
-        K=105,
-        # Projected (FanGraphs) - full season
-        proj_wins=15,
-        proj_strikeouts=210,
-        proj_innings_pitched=190.0,
+        current_season=MtblPitcherSeasonStatsModel(
+            # Current (ESPN)
+            K=90,  # Through half season
+            OUTS=480,  # 160 IP (3 outs per inning)
+        ),
+        projections=FangraphsPitcherStatsModel(
+            strikeouts=180,  # Full season projection
+            innings_pitched=190,
+        ),
     )
 
+    assert stats.current_season is not None
+
     # Verify we can track both current and projected
-    assert stats.W == 8
-    assert stats.proj_wins == 15
-    assert stats.K == 105
-    assert stats.proj_strikeouts == 210
+    assert stats.current_season.K == 90
+    assert stats.projections.strikeouts == 180
+
+    # Can calculate K/9 pace
+    if stats.current_season.OUTS and stats.current_season.OUTS > 0:
+        innings = stats.current_season.OUTS / 3
+        k_per_9 = (stats.current_season.K / innings) * 9
+        assert k_per_9 == pytest.approx(5.06, abs=0.1)
 
 
 def test_pitcher_stats_model_dump():
     """Test that model_dump works correctly with all stats."""
     stats = MtblPitcherStatsModel(
-        W=12, ERA=3.45, proj_wins=13, proj_fip=3.25, velo=94.5
+        current_season=MtblPitcherSeasonStatsModel(
+            W=15,
+            ERA=3.25,
+            velo=96.0,
+        ),
+        projections=FangraphsPitcherStatsModel(
+            era=3.10,
+        ),
     )
 
     dumped = stats.model_dump(exclude_none=True)
 
-    assert dumped["W"] == 12
-    assert dumped["ERA"] == 3.45
-    assert dumped["proj_wins"] == 13
-    assert dumped["proj_fip"] == 3.25
-    assert dumped["velo"] == 94.5
+    assert dumped["current_season"]["W"] == 15
+    assert dumped["current_season"]["ERA"] == 3.25
+    assert dumped["current_season"]["velo"] == 96.0
+    assert dumped["projections"]["era"] == 3.10
 
     # None values should be excluded
-    assert "L" not in dumped
-    assert "proj_era" not in dumped
-    assert "spin_rate" not in dumped
+    assert "WHIP" not in dumped["current_season"]
+    assert "proj_whip" not in dumped["current_season"]
+    assert "spin_rate" not in dumped["current_season"]
 
 
-def test_pitcher_stats_starter_metrics():
-    """Test metrics specific to starting pitchers."""
+def test_pitcher_stats_plate_discipline_metrics():
+    """Test plate discipline metrics from all sources."""
     stats = MtblPitcherStatsModel(
-        # ESPN starter metrics
-        W=14,
-        L=7,
-        QS=20,
-        GS=28,
-        GP=28,
-        # FanGraphs starter projections
-        proj_wins=13,
-        proj_quality_starts=18,
-        proj_games_started=30,
-        proj_innings_pitched=190.0,
-        # Savant pitch characteristics
-        velo=93.5,
-        spin_rate=2425,
-        release_extension=6.1,
+        current_season=MtblPitcherSeasonStatsModel(
+            # ESPN plate discipline
+            P_BB=45,
+            K=190,
+            TBF=750,
+
+            # Savant plate discipline
+            swing_miss_pct=31.0,
+            swings=520,
+            whiffs=160,
+            takes=180,
+        ),
+        projections=FangraphsPitcherStatsModel(
+            walks=50,
+            strikeouts=185,
+            k_per_bb=3.8,
+        ),
     )
+
+    assert stats.current_season is not None
 
     # ESPN
-    assert stats.W == 14
-    assert stats.QS == 20
-    assert stats.GS == 28
+    assert stats.current_season.P_BB == 45
+    assert stats.current_season.K == 190
+    assert stats.current_season.TBF == 750
 
     # FanGraphs
-    assert stats.proj_wins == 13
-    assert stats.proj_quality_starts == 18
-    assert stats.proj_games_started == 30
+    assert stats.projections.walks == 50
+    assert stats.projections.strikeouts == 185
+    assert stats.projections.k_per_bb == 3.8
 
     # Savant
-    assert stats.velo == 93.5
-    assert stats.spin_rate == 2425
-    assert stats.release_extension == 6.1
+    assert stats.current_season.swing_miss_pct == 31.0
+    assert stats.current_season.swings == 520
+    assert stats.current_season.whiffs == 160
+    assert stats.current_season.takes == 180
 
 
-def test_pitcher_stats_command_control_metrics():
-    """Test command and control metrics from all sources."""
+def test_pitcher_stats_pitch_characteristics_metrics():
+    """Test pitch characteristics metrics from Savant."""
     stats = MtblPitcherStatsModel(
-        # ESPN command metrics
-        P_BB=42,
-        K=195,
-        WHIP=1.15,
-        # FanGraphs command projections
-        proj_walks=38,
-        proj_strikeouts=205,
-        proj_bb_per_9=1.90,
-        proj_k_per_9=10.25,
-        proj_k_per_bb=5.39,
-        # Savant discipline metrics
-        swing_miss_pct=29.2,
-        BB_pct=6.8,
-        whiffs=450,
-        swings=1550,
-        takes=850,
+        current_season=MtblPitcherSeasonStatsModel(
+            velo=98.1,
+            spin_rate=2550,
+            eff_min_vel=95.3,
+            percieved_velo=97.0,
+            release_extension=7.0,
+            release_pos_x=1.2,
+            release_pos_z=5.8,
+        )
     )
 
-    # ESPN
-    assert stats.P_BB == 42
-    assert stats.K == 195
-    assert stats.WHIP == 1.15
-
-    # FanGraphs
-    assert stats.proj_walks == 38
-    assert stats.proj_strikeouts == 205
-    assert stats.proj_bb_per_9 == 1.90
-    assert stats.proj_k_per_9 == 10.25
-    assert stats.proj_k_per_bb == 5.39
-
-    # Savant
-    assert stats.swing_miss_pct == 29.2
-    assert stats.BB_pct == 6.8
-    assert stats.whiffs == 450
-    assert stats.swings == 1550
-    assert stats.takes == 850
+    assert stats.current_season is not None
+    assert stats.current_season.velo == 98.1
+    assert stats.current_season.spin_rate == 2550
+    assert stats.current_season.eff_min_vel == 95.3
+    assert stats.current_season.percieved_velo == 97.0
+    assert stats.current_season.release_extension == 7.0
+    assert stats.current_season.release_pos_x == 1.2
+    assert stats.current_season.release_pos_z == 5.8
 
 
-def test_pitcher_stats_contact_quality_allowed():
-    """Test contact quality metrics allowed from Savant."""
+def test_pitcher_stats_movement_metrics():
+    """Test pitch movement metrics from Savant."""
     stats = MtblPitcherStatsModel(
-        exit_velo=87.5,
-        adj_exit_velo=87.8,
-        launch_angle=12.5,
-        xavg=0.235,
-        xslg=0.395,
-        xwoba=0.305,
-        BABIP=0.285,
-        ISO=0.160,
+        current_season=MtblPitcherSeasonStatsModel(
+            break_z=15.8,
+            induced_break_z=12.4,
+            break_x_arm_side=7.2,
+            break_x_batter_in=5.5,
+        )
     )
 
-    assert stats.exit_velo == 87.5
-    assert stats.adj_exit_velo == 87.8
-    assert stats.launch_angle == 12.5
-    assert stats.xavg == 0.235
-    assert stats.xslg == 0.395
-    assert stats.xwoba == 0.305
-    assert stats.BABIP == 0.285
-    assert stats.ISO == 0.160
+    assert stats.current_season is not None
+    assert stats.current_season.break_z == 15.8
+    assert stats.current_season.induced_break_z == 12.4
+    assert stats.current_season.break_x_arm_side == 7.2
+    assert stats.current_season.break_x_batter_in == 5.5
 
 
-def test_pitcher_stats_pitch_arsenal():
-    """Test pitch arsenal metrics from Savant."""
+def test_pitcher_stats_mechanics_and_performance_metrics():
+    """Test mechanics and performance metrics from Savant."""
     stats = MtblPitcherStatsModel(
-        velo=94.2,
-        spin_rate=2425,
-        release_extension=6.3,
-        break_z=18.5,
-        break_x_arm_side=-8.2,
-        induced_break_z=16.8,
-        arm_angle=42.5,
-        release_pos_x=-2.1,
-        release_pos_z=5.8,
+        current_season=MtblPitcherSeasonStatsModel(
+            arm_angle=45.5,
+            pitcher_run_exp=1.2,
+            pitcher_run_value_per_100=5.8,
+        )
     )
 
-    assert stats.velo == 94.2
-    assert stats.spin_rate == 2425
-    assert stats.release_extension == 6.3
-    assert stats.break_z == 18.5
-    assert stats.break_x_arm_side == -8.2
-    assert stats.induced_break_z == 16.8
-    assert stats.arm_angle == 42.5
-    assert stats.release_pos_x == -2.1
-    assert stats.release_pos_z == 5.8
+    assert stats.current_season is not None
+    assert stats.current_season.arm_angle == 45.5
+    assert stats.current_season.pitcher_run_exp == 1.2
+    assert stats.current_season.pitcher_run_value_per_100 == 5.8
+
+
+def test_pitcher_stats_contact_metrics():
+    """Test contact/batted ball metrics from Savant."""
+    stats = MtblPitcherStatsModel(
+        current_season=MtblPitcherSeasonStatsModel(
+            exit_velo=88.5,
+            adj_exit_velo=89.2,
+            launch_angle=12.8,
+        )
+    )
+
+    assert stats.current_season is not None
+    assert stats.current_season.exit_velo == 88.5
+    assert stats.current_season.adj_exit_velo == 89.2
+    assert stats.current_season.launch_angle == 12.8
+
+
+def test_pitcher_stats_expected_stats():
+    """Test expected stats from Savant."""
+    stats = MtblPitcherStatsModel(
+        current_season=MtblPitcherSeasonStatsModel(
+            xwoba=0.290,
+            xavg=0.225,
+            xslg=0.375,
+            xAVG=0.225,
+            xSLG=0.375,
+            xSLGdiff=0.015,
+        )
+    )
+
+    assert stats.current_season is not None
+    assert stats.current_season.xwoba == 0.290
+    assert stats.current_season.xavg == 0.225
+    assert stats.current_season.xslg == 0.375
+    assert stats.current_season.xAVG == 0.225
+    assert stats.current_season.xSLG == 0.375
+    assert stats.current_season.xSLGdiff == 0.015
+
+
+def test_pitcher_stats_other_savant_stats():
+    """Test other Savant stats for pitchers."""
+    stats = MtblPitcherStatsModel(
+        current_season=MtblPitcherSeasonStatsModel(
+            BABIP=0.290,
+            BB=45,
+            BB_pct=8.5,
+            BBdist=32,
+            BIP=420,
+            ISO=0.165,
+            wOBA=0.315,
+            wOBAdiff=0.010,
+            run_exp=1.5,
+            barrels_total=18,
+            rate_ideal_attack_angle=12.5,
+        )
+    )
+
+    assert stats.current_season is not None
+    assert stats.current_season.BABIP == 0.290
+    assert stats.current_season.BB == 45
+    assert stats.current_season.BB_pct == 8.5
+    assert stats.current_season.BBdist == 32
+    assert stats.current_season.BIP == 420
+    assert stats.current_season.ISO == 0.165
+    assert stats.current_season.wOBA == 0.315
+    assert stats.current_season.wOBAdiff == 0.010
+    assert stats.current_season.run_exp == 1.5
+    assert stats.current_season.barrels_total == 18
+    assert stats.current_season.rate_ideal_attack_angle == 12.5


### PR DESCRIPTION
### Motivation
- Separate FanGraphs projections from current-season metrics for clearer model boundaries and easier consumer usage.
- Ensure Savant sabermetrics do not overwrite ESPN current-season values when both sources provide the same field.
- Preserve the ESPN stats container with all historical periods while exposing a single top-level MTBL stats container.
- Update tests and match/merge logic to reflect the new nested layout and merge semantics.

### Description
- Introduced `MtblBatterSeasonStatsModel` and `MtblPitcherSeasonStatsModel` and added a `projections: Fangraphs*StatsModel` field to `MtblBatterStatsModel` and `MtblPitcherStatsModel` in `player_universe_trx/models/mtbl/stats.py`.
- Updated the matcher to return a separate `projections_dict` from `_extract_fangraphs_projections`, to build `current_season` from ESPN+Savant, and to only add Savant fields when the corresponding ESPN field is not already present in `_build_stats_dict` (ESPN wins on collision) in `player_universe_trx/matchers/player_matcher.py`.
- Constructed `Fangraphs*StatsModel` instances from `projections_dict` and attach them to the player stats object, and exported the new season models in `player_universe_trx/models/mtbl/__init__.py`.
- Updated unit tests under `tests/models/mtbl/` and `tests/matchers/` to assert the new `stats.current_season` and `stats.projections` layout and adjusted expectations accordingly.

### Testing
- Unit tests in `tests/models/mtbl/` and `tests/matchers/` were updated to reflect the nested `projections` and `current_season` layout, but no test runner was executed in this rollout.
- No automated test run was executed as part of this change (pytest was not run).
- Recommended verification commands: run `uv run pytest` (or `pytest`) to validate behavior locally or in CI.
- Also consider running type and lint checks with `uv run mypy player_universe_trx/` and `uv run ruff check player_universe_trx/`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ec442a9988321baf0f09628bcbd4f)