### PR TITLE
Strip identity noise from Savant sub-domain serialized output

### DIFF
--- a/player_universe_trx/utils/model_utils.py
+++ b/player_universe_trx/utils/model_utils.py
@@ -146,6 +146,15 @@ _SAVANT_IDENTITY_FIELDS = {
     "season",
 }
 
+# Pure player/team identity + loader-added consolidation metadata carried by
+# sub-domain wire rows. These are redundant inside a stat sub-object — the
+# parent MtblPlayerModel already carries identity — so they're stripped at the
+# sub-domain indexing boundary to keep them from leaking through the models'
+# extra="allow" config into the serialized output. Note: `year` and `team_id`
+# are deliberately NOT here — some sub-domain models (home_runs,
+# expected_statistics, swing_take) declare them as real stat-context fields.
+_SAVANT_SUBDOMAIN_NOISE_FIELDS = _SAVANT_IDENTITY_FIELDS | {"team"}
+
 # Maps Savant's opp_hand wire value to the model field name. The extractor
 # emits one row per opp_hand per player.
 _OPP_HAND_TO_SLOT = {"all": "all", "R": "vs_r", "L": "vs_l"}
@@ -230,8 +239,14 @@ def _index_savant_subdomain(
 ) -> Dict[int, Any]:
     """Build a player_id → row (or list of rows) lookup from a sub-domain file.
 
-    NaN floats are scrubbed at the row level so the merged data validates
-    cleanly downstream. Rows without a player_id are dropped with a debug log.
+    Each row is cleaned before storage:
+      - NaN floats are scrubbed so the merged data validates cleanly downstream.
+      - Identity / metadata noise (name, slug, player_id, team, ...) is dropped
+        so it doesn't leak into the serialized stat sub-object via the models'
+        extra="allow" config — the parent player record already carries
+        identity. Genuine stat-context fields (`year`, `team_id`) survive.
+
+    Rows without a player_id are dropped with a debug log.
 
     Args:
         rows: Raw rows from one of the sub-domain JSON files (already
@@ -250,7 +265,13 @@ def _index_savant_subdomain(
                 f"Skipped Savant sub-domain row with no player_id: {row.get('name')}"
             )
             continue
-        cleaned = _scrub_nan(row)
+        # player_id is captured above for the lookup key; strip it (and the
+        # rest of the identity/metadata noise) from the stored stat dict.
+        cleaned = {
+            k: v
+            for k, v in _scrub_nan(row).items()
+            if k not in _SAVANT_SUBDOMAIN_NOISE_FIELDS
+        }
         if multi_value:
             out.setdefault(pid, []).append(cleaned)
         else:

--- a/tests/utils/test_model_utils.py
+++ b/tests/utils/test_model_utils.py
@@ -507,6 +507,52 @@ def test_subdomain_merge_attaches_statcast_to_matching_player():
     assert m.statcast.avg_ev == 89.0
 
 
+def test_subdomain_merge_strips_identity_noise_keeps_context_fields():
+    """Sub-domain stat objects don't leak player/team identity into their serialized form.
+
+    The wire rows carry full identity (name/slug/player_id/team/...) plus
+    loader-added player_type/season. None of that belongs inside a stat
+    sub-object — the parent player record already has it. The indexing
+    boundary strips it. Declared stat-context fields (`year`, `team_id`)
+    must survive since some sub-domain models legitimately expose them.
+    """
+    base = [_savant_batter_row(100, "all", xwOBA=0.300)]
+    # A swing_take-shaped row carrying the full identity noise set + real
+    # stats + the declared context fields year/team_id.
+    noisy_row = {
+        "player_id": 100,
+        "name": "Test, Player",
+        "first_name": "Test",
+        "last_name": "Player",
+        "name_ascii": "Test Player",
+        "slug": "test-player",
+        "player_type": "batter",
+        "season": 2026,
+        "team": "NYY",
+        "year": 2026,
+        "team_id": 147,
+        "runs_all": 7.1,
+        "runs_heart": -2.9,
+    }
+    models = create_savant_batter_models(base, swing_take_data=[noisy_row])
+    st = models[0].swing_take
+    assert st is not None
+    dumped = st.model_dump(exclude_none=True)
+
+    # No identity / metadata noise survived into the serialized stat object
+    leaked = {
+        "name", "first_name", "last_name", "name_ascii", "slug",
+        "player_id", "player_type", "season", "team",
+    } & set(dumped)
+    assert leaked == set(), f"identity leaked into swing_take: {leaked}"
+
+    # Real stats + declared context fields survived intact
+    assert dumped["runs_all"] == 7.1
+    assert dumped["runs_heart"] == -2.9
+    assert dumped["year"] == 2026
+    assert dumped["team_id"] == 147
+
+
 def test_subdomain_merge_skips_unmatched_player_id():
     """A statcast row for a player_id not in the base file is ignored."""
     base = [_savant_batter_row(100, "all", xwOBA=0.300)]


### PR DESCRIPTION
## Summary
Every Savant sub-domain (`statcast` / `home_runs` / `pitch_arsenal` / `sprint_speed` / `expected_statistics` / `swing_take`) was serializing with redundant player identity nested inside it — `name`, `first_name`, `last_name`, `name_ascii`, `slug`, `player_id`, plus loader-added `player_type`/`season` and the `team` abbreviation string.

None of those are declared by any sub-domain stat model. They leaked through `SAVANT_STATS_MODEL_CONFIG`'s `extra="allow"` because `_index_savant_subdomain` passed the whole wire row into the model.

## Why this is worth doing
- **Best practice**: identity belongs on the player record, not duplicated 6× inside one player's `savant` bundle. The parent `MtblPlayerModel` already carries `name`/`slug`/`id_*`/`team` at the top level.
- **Performance**: measurable JSON bloat — ~8 redundant fields × 6 sub-domains × ~1000 Savant-matched players.

## Fix
Strip the known identity/metadata noise set at the indexing boundary (`_index_savant_subdomain`) before the row reaches the model. Implementation detail:
- New `_SAVANT_SUBDOMAIN_NOISE_FIELDS = _SAVANT_IDENTITY_FIELDS | {"team"}` — reuses the existing identity constant.
- `extra="allow"` is **preserved** — genuinely-new *stat* fields still round-trip for forward-compat; only the identity noise is dropped.
- Declared stat-context fields (`year`, `team_id`) deliberately survive — `year` is declared by home_runs/expected_statistics/swing_take, `team_id` by swing_take.

## Impact (end-to-end pipeline, 2026 fixtures)
| File | Before | After | Δ |
|---|---:|---:|---:|
| batters_matched.json | 17.35 MB | 16.65 MB | **-4.1%** |
| pitchers_matched.json | 19.61 MB | 18.99 MB | **-3.2%** |
| **total player output** | **44.85 MB** | **43.53 MB** | **-3.0% (-1.32 MB)** |

`*_ambiguous` / `*_unmatched` files unchanged at 0% — they carry no Savant bundles, confirming the fix is surgically scoped to exactly the matched-player Savant data.

## Test plan
- [x] `uv run pytest tests/` — 227 passing (+1 new regression test pinning the no-leak contract, including that `year`/`team_id` survive)
- [x] Pre-commit mypy clean
- [x] **100% coverage held** across `player_universe_trx`
- [x] End-to-end run: `universe-trx --year 2026` exits 0; verified zero identity leaks across all 6 sub-domains on all matched players; declared context fields + real stats intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)