### PR TITLE
Add rich progress bars to player matching pipeline

### DIFF
--- a/player_universe_trx/__main__.py
+++ b/player_universe_trx/__main__.py
@@ -1,7 +1,20 @@
 import argparse
 import logging
+import sys
+from contextlib import contextmanager
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterator, Optional
+
+from rich.console import Console, Group
+from rich.live import Live
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
 
 from player_universe_trx.loaders import DataLoader
 from player_universe_trx.loaders.league_loader import LeagueLoader
@@ -29,6 +42,37 @@ logger = logging.getLogger("player_universe_trx")
 
 OUTPUT_DIR = "/Users/Shared/BaseballHQ/resources/transform"
 RESOURCE_DIR = "/Users/Shared/BaseballHQ/resources/extract"
+
+
+@contextmanager
+def _route_stdout_log_handlers_through_live() -> Iterator[None]:
+    """Repoint every stdout-bound logging.StreamHandler at the current
+    ``sys.stdout`` for the duration of the context so log lines interleave
+    above a ``rich.live.Live`` region without tearing the progress bars.
+
+    Existing handlers cached the original ``sys.stdout`` at construction
+    time, so Live's stdout redirect doesn't reach them unless we re-point
+    their stream.
+    """
+    restorations: list[tuple[logging.StreamHandler, object]] = []
+    seen: set[int] = set()
+    logger_names = ["root", *logging.Logger.manager.loggerDict.keys()]
+    for name in logger_names:
+        lg = logging.getLogger(None if name == "root" else name)
+        for h in lg.handlers:
+            if (
+                isinstance(h, logging.StreamHandler)
+                and not isinstance(h, logging.FileHandler)
+                and id(h) not in seen
+            ):
+                seen.add(id(h))
+                restorations.append((h, h.stream))
+                h.setStream(sys.stdout)
+    try:
+        yield
+    finally:
+        for handler, original in restorations:
+            handler.setStream(original)
 
 
 def transform_league_data(
@@ -198,24 +242,61 @@ def main(
         swing_take_data=swing_take_pitchers_raw,
     )
 
-    # Match batters
-    logger.info("Matching batters across ESPN, FanGraphs, and Savant...")
+    # Match batters and pitchers under a unified progress display. The top
+    # group bar shows per-role progress, the bottom bar is the overall
+    # total across both roles. A single Console is shared so any log lines
+    # emitted during matching render above the Live region without tearing.
+    logger.info("Matching batters and pitchers across ESPN, FanGraphs, and Savant...")
     batter_matcher = PlayerMatcher(
         espn_players=espn_batters,
         fangraphs_data=fangraphs_batters,
         savant_data=savant_batters,
     )
-    batter_results = batter_matcher.match_players()
-    batter_merged = apply_matches(batter_results)
-
-    # Match pitchers
-    logger.info("Matching pitchers across ESPN, FanGraphs, and Savant...")
     pitcher_matcher = PlayerMatcher(
         espn_players=espn_pitchers,
         fangraphs_data=fangraphs_pitchers,
         savant_data=savant_pitchers,
     )
-    pitcher_results = pitcher_matcher.match_players()
+
+    console = Console()
+    progress_columns = (
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        MofNCompleteColumn(),
+        TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+        TimeElapsedColumn(),
+        TimeRemainingColumn(),
+    )
+    group_progress = Progress(*progress_columns, console=console, transient=False)
+    overall_progress = Progress(*progress_columns, console=console, transient=False)
+
+    with Live(
+        Group(group_progress, overall_progress),
+        console=console,
+        refresh_per_second=10,
+        redirect_stdout=True,
+        redirect_stderr=True,
+    ), _route_stdout_log_handlers_through_live():
+        batter_task = group_progress.add_task("Batters", total=len(espn_batters))
+        pitcher_task = group_progress.add_task("Pitchers", total=len(espn_pitchers))
+        overall_task = overall_progress.add_task(
+            "Total progress", total=len(espn_batters) + len(espn_pitchers)
+        )
+
+        def _advance_batter() -> None:
+            group_progress.advance(batter_task)
+            overall_progress.advance(overall_task)
+
+        def _advance_pitcher() -> None:
+            group_progress.advance(pitcher_task)
+            overall_progress.advance(overall_task)
+
+        batter_results = batter_matcher.match_players(progress_advance=_advance_batter)
+        pitcher_results = pitcher_matcher.match_players(
+            progress_advance=_advance_pitcher
+        )
+
+    batter_merged = apply_matches(batter_results)
     pitcher_merged = apply_matches(pitcher_results)
 
     # Combine results

--- a/player_universe_trx/__main__.py
+++ b/player_universe_trx/__main__.py
@@ -34,10 +34,31 @@ from player_universe_trx.utils.model_utils import (
 )
 from player_universe_trx.utils.output_utils import save_results
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+_PACKAGE_PREFIX = "player_universe_trx."
+
+
+class _StripPackagePrefixFormatter(logging.Formatter):
+    """Drop the ``player_universe_trx.`` prefix from ``record.name`` so log
+    lines render the rest of the dotted path (e.g. ``matchers.player_matcher``)
+    without the redundant top-level package name on every line.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        if record.name.startswith(_PACKAGE_PREFIX):
+            record.name = record.name[len(_PACKAGE_PREFIX):]
+        return super().format(record)
+
+
+# Configure logging. Calling basicConfig first installs a default root
+# StreamHandler if none exists; we then swap its formatter for the
+# prefix-stripping variant so every logger in the package gets the same
+# treatment via propagation.
+logging.basicConfig(level=logging.INFO)
+_stripping_formatter = _StripPackagePrefixFormatter(
+    "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
+for _h in logging.getLogger().handlers:
+    _h.setFormatter(_stripping_formatter)
 logger = logging.getLogger("player_universe_trx")
 
 OUTPUT_DIR = "/Users/Shared/BaseballHQ/resources/transform"

--- a/player_universe_trx/__main__.py
+++ b/player_universe_trx/__main__.py
@@ -3,7 +3,7 @@ import logging
 import sys
 from contextlib import contextmanager
 from datetime import datetime
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Dict, Iterator, Optional, TextIO
 
 from rich.console import Console, Group
 from rich.live import Live
@@ -66,29 +66,42 @@ RESOURCE_DIR = "/Users/Shared/BaseballHQ/resources/extract"
 
 
 @contextmanager
-def _route_stdout_log_handlers_through_live() -> Iterator[None]:
-    """Repoint every stdout-bound logging.StreamHandler at the current
-    ``sys.stdout`` for the duration of the context so log lines interleave
-    above a ``rich.live.Live`` region without tearing the progress bars.
+def _route_std_log_handlers_through_live() -> Iterator[None]:
+    """Repoint each std{out,err}-bound logging.StreamHandler at the
+    matching redirected stream for the duration of the context so log
+    lines interleave above a ``rich.live.Live`` region without tearing
+    the progress bars.
 
-    Existing handlers cached the original ``sys.stdout`` at construction
-    time, so Live's stdout redirect doesn't reach them unless we re-point
-    their stream.
+    Existing handlers cached the original ``sys.__stdout__`` /
+    ``sys.__stderr__`` at construction time, so Live's redirects don't
+    reach them unless we re-point. Stdout-bound handlers move to the
+    redirected ``sys.stdout``; stderr-bound handlers move to the
+    redirected ``sys.stderr`` — preserving channel semantics so callers
+    that pipe stdout and stderr separately still see warnings/errors on
+    stderr. Handlers bound to any other stream are left untouched.
     """
-    restorations: list[tuple[logging.StreamHandler, object]] = []
+    restorations: list[tuple[logging.StreamHandler, TextIO]] = []
     seen: set[int] = set()
     logger_names = ["root", *logging.Logger.manager.loggerDict.keys()]
     for name in logger_names:
         lg = logging.getLogger(None if name == "root" else name)
         for h in lg.handlers:
             if (
-                isinstance(h, logging.StreamHandler)
-                and not isinstance(h, logging.FileHandler)
-                and id(h) not in seen
+                not isinstance(h, logging.StreamHandler)
+                or isinstance(h, logging.FileHandler)
+                or id(h) in seen
             ):
-                seen.add(id(h))
-                restorations.append((h, h.stream))
-                h.setStream(sys.stdout)
+                continue
+            seen.add(id(h))
+            new_stream: TextIO
+            if h.stream is sys.__stdout__:
+                new_stream = sys.stdout
+            elif h.stream is sys.__stderr__:
+                new_stream = sys.stderr
+            else:
+                continue
+            restorations.append((h, h.stream))
+            h.setStream(new_stream)
     try:
         yield
     finally:
@@ -297,7 +310,7 @@ def main(
         refresh_per_second=10,
         redirect_stdout=True,
         redirect_stderr=True,
-    ), _route_stdout_log_handlers_through_live():
+    ), _route_std_log_handlers_through_live():
         batter_task = group_progress.add_task("Batters", total=len(espn_batters))
         pitcher_task = group_progress.add_task("Pitchers", total=len(espn_pitchers))
         overall_task = overall_progress.add_task(

--- a/player_universe_trx/matchers/player_matcher.py
+++ b/player_universe_trx/matchers/player_matcher.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Optional, Sequence, Set, Tuple
+from typing import Callable, Dict, List, Optional, Sequence, Set, Tuple
 
 from typing_extensions import TYPE_CHECKING
 
@@ -537,9 +537,17 @@ class PlayerMatcher:
             notes="No definitive match found",
         )
 
-    def match_players(self) -> List[PlayerMatchResult]:
+    def match_players(
+        self,
+        progress_advance: Optional[Callable[[], None]] = None,
+    ) -> List[PlayerMatchResult]:
         """
         Match all ESPN players against FanGraphs and Savant data.
+
+        Args:
+            progress_advance: Optional callable invoked once per player after
+                that player's match attempt completes. Lets callers drive a
+                progress bar without coupling this method to a UI library.
 
         Returns:
             List of PlayerMatchResult objects (one per ESPN player)
@@ -573,5 +581,8 @@ class PlayerMatcher:
                     self.matched_savant_ids.add((savant_id, savant_type))
 
             results.append(result)
+
+            if progress_advance is not None:
+                progress_advance()
 
         return results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,10 @@ description = "Player Universe Transformer"
 authors = [{ name = "Taylor \"TP\" Pubins", email = "tpubz@icloud.com" }]
 readme = "README.md"
 requires-python = ">=3.13"
-dependencies = ["pydantic (>=2.11.4,<3.0.0)"]
+dependencies = [
+    "pydantic (>=2.11.4,<3.0.0)",
+    "rich (>=13.0.0,<15.0.0)",
+]
 
 [project.scripts]
 universe-trx = "player_universe_trx.__main__:cli"

--- a/tests/matchers/test_coverage_final.py
+++ b/tests/matchers/test_coverage_final.py
@@ -195,3 +195,33 @@ def test_apply_matches_retired_player():
     assert len(output["matched"]) == 0
     assert len(output["unmatched"]) == 0
     assert len(output["ambiguous"]) == 0
+
+
+def test_match_players_invokes_progress_callback():
+    """match_players should call progress_advance once per ESPN player when
+    a callback is supplied (covers the optional progress-bar hook)."""
+    espn_players = [
+        EspnBatterModel(
+            id=i,
+            name=f"Player {i}",
+            first_name="Player",
+            last_name=str(i),
+            slug=f"player-{i}",
+        )
+        for i in range(3)
+    ]
+    fg_players = [
+        FangraphsBatterModel(name=f"Player {i}", playerid=str(100 + i), slug=f"player-{i}")
+        for i in range(3)
+    ]
+
+    matcher = PlayerMatcher(espn_players, fg_players)
+    calls: list[int] = []
+
+    def _advance() -> None:
+        calls.append(1)
+
+    results = matcher.match_players(progress_advance=_advance)
+
+    assert len(results) == 3
+    assert len(calls) == 3

--- a/uv.lock
+++ b/uv.lock
@@ -71,6 +71,27 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "1.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -126,6 +147,7 @@ version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
+    { name = "rich" },
 ]
 
 [package.dev-dependencies]
@@ -137,7 +159,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pydantic", specifier = ">=2.11.4,<3.0.0" }]
+requires-dist = [
+    { name = "pydantic", specifier = ">=2.11.4,<3.0.0" },
+    { name = "rich", specifier = ">=13.0.0,<15.0.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -243,6 +268,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/69/5f1e57f6c5a39f81411b550027bf72842c4567ff5fd572bed1edc9e4b5d9/pytest_cov-6.1.1.tar.gz", hash = "sha256:46935f7aaefba760e716c2ebfbe1c216240b9592966e7da99ea8292d4d3e2a0a", size = 66857, upload-time = "2025-04-05T14:07:51.592Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/28/d0/def53b4a790cfb21483016430ed828f64830dd981ebe1089971cd10cab25/pytest_cov-6.1.1-py3-none-any.whl", hash = "sha256:bddf29ed2d0ab6f4df17b4c55b0a657287db8684af9c42ea546b21b1041b3dde", size = 23841, upload-time = "2025-04-05T14:07:49.641Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Wrap the batter + pitcher `PlayerMatcher.match_players()` calls in a unified `rich.live.Live` region with stacked progress bars: per-role (Batters / Pitchers) on top, overall total below.
- Add `progress_advance: Optional[Callable[[], None]]` to `PlayerMatcher.match_players()` so the matcher reports per-player progress without coupling to a UI library.
- Add `rich>=13.0.0,<15.0.0` runtime dependency.
- Re-point existing stdout-bound `logging.StreamHandler`s at Live's redirected `sys.stdout` while the bars are active so INFO lines interleave above the bars instead of tearing them.

Mirrors the progress UX added in `ESPN_API_Extractor` (PR #16) and `Savant_API_Extractor` (PR #18).

## Test plan
- [x] `uv run pytest tests/ -q` — 228 passed
- [x] `uv run mypy player_universe_trx/__main__.py player_universe_trx/matchers/player_matcher.py` — clean
- [ ] Live run via `uv run universe-trx --year 2026 ...` to confirm both bars render and INFO lines do not tear

🤖 Generated with [Claude Code](https://claude.com/claude-code)