### PR TITLE
feat: preserve league name and per-category matchup breakdown

### DIFF
--- a/player_universe_trx/models/espn/__init__.py
+++ b/player_universe_trx/models/espn/__init__.py
@@ -4,6 +4,7 @@ from player_universe_trx.models.espn.batter import (
 )
 from player_universe_trx.models.espn.espn_player import EspnPlayerModel
 from player_universe_trx.models.espn.league import (
+    EspnCategoryResultModel,
     EspnLeagueModel,
     EspnLeagueSettingsModel,
     EspnPlayerMinimalModel,
@@ -13,6 +14,7 @@ from player_universe_trx.models.espn.league import (
     EspnRosterEntryModel,
     EspnRosterModel,
     EspnRosterSettingsModel,
+    EspnScheduleMatchupModel,
     EspnTeamModel,
 )
 from player_universe_trx.models.espn.pitcher import (
@@ -42,4 +44,6 @@ __all__ = [
     "EspnRecordDetailModel",
     "EspnLeagueSettingsModel",
     "EspnRosterSettingsModel",
+    "EspnScheduleMatchupModel",
+    "EspnCategoryResultModel",
 ]

--- a/player_universe_trx/models/espn/league.py
+++ b/player_universe_trx/models/espn/league.py
@@ -138,6 +138,7 @@ class EspnRosterSettingsModel(BaseModel):
 class EspnLeagueSettingsModel(BaseModel):
     """League settings."""
 
+    name: Optional[str] = None
     rosterSettings: Optional[EspnRosterSettingsModel] = Field(
         None, alias="rosterSettings"
     )
@@ -190,6 +191,15 @@ class EspnTeamModel(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
+class EspnCategoryResultModel(BaseModel):
+    """A single scoring category's outcome within a matchup."""
+
+    value: Optional[float] = None
+    result: Optional[str] = None  # WIN / LOSS / TIE
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
 class EspnScheduleMatchupModel(BaseModel):
     """Individual schedule matchup."""
 
@@ -198,6 +208,11 @@ class EspnScheduleMatchupModel(BaseModel):
     playoffTierType: Optional[str] = Field(None, alias="playoffTierType")
     winner: Optional[int | str] = None  # Can be team_id (int) or "BYE WEEK" (str)
     teams: Dict[str, str] = Field(default_factory=dict)  # team_id -> score string
+    # Per-category breakdown for H2H category leagues: team_id -> {category ->
+    # result}. Absent for points/roster-limit leagues (no scoreByStat upstream).
+    categoryResults: Optional[Dict[str, Dict[str, EspnCategoryResultModel]]] = Field(
+        None, alias="categoryResults"
+    )
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/player_universe_trx/models/mtbl/__init__.py
+++ b/player_universe_trx/models/mtbl/__init__.py
@@ -2,6 +2,7 @@
 
 from player_universe_trx.models.mtbl.batter import MtblBatterModel
 from player_universe_trx.models.mtbl.league import (
+    CategoryResultModel,
     MtblLeagueModel,
     MtblScheduleModel,
     MtblTeamRosterModel,
@@ -34,6 +35,7 @@ __all__ = [
     "MtblPitcherFangraphsBundle",
     "MtblPitcherSavantBundle",
     "MtblPitcherStatsModel",
+    "CategoryResultModel",
     "MtblLeagueModel",
     "MtblScheduleModel",
     "MtblTeamRosterModel",

--- a/player_universe_trx/models/mtbl/league.py
+++ b/player_universe_trx/models/mtbl/league.py
@@ -150,6 +150,7 @@ class MtblLeagueModel(BaseModel):
     """MTBL league summary model."""
 
     league_id: int
+    league_name: Optional[str] = None
     season_id: int
     scoring_period_id: Optional[int] = None
     num_teams: int
@@ -157,6 +158,16 @@ class MtblLeagueModel(BaseModel):
     scoring_categories: Optional[ScoringCategoriesModel] = None
     acquisition_budget: Optional[int] = None
     draft_auction_budget: Optional[int] = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class CategoryResultModel(BaseModel):
+    """A single scoring category's outcome for a team within a matchup."""
+
+    category: str
+    value: Optional[float] = None
+    result: Optional[str] = None  # WIN / LOSS / TIE
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -173,6 +184,9 @@ class ScheduleMatchupModel(BaseModel):
     team2_score: Optional[str] = None
     winner_id: Optional[int] = None
     is_bye_week: bool = False
+    # Per-category breakdown, populated only for H2H category leagues.
+    team1_categories: Optional[List[CategoryResultModel]] = None
+    team2_categories: Optional[List[CategoryResultModel]] = None
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/player_universe_trx/transformers/league_transformer.py
+++ b/player_universe_trx/transformers/league_transformer.py
@@ -13,9 +13,11 @@ from player_universe_trx.constants import (
 from player_universe_trx.models.espn import (
     EspnLeagueModel,
     EspnRosterEntryModel,
+    EspnScheduleMatchupModel,
     EspnTeamModel,
 )
 from player_universe_trx.models.mtbl import (
+    CategoryResultModel,
     MtblLeagueModel,
     MtblScheduleModel,
     MtblTeamRosterModel,
@@ -380,8 +382,14 @@ class LeagueTransformer:
         if espn_league.settings and espn_league.settings.draftSettings:
             draft_auction_budget = espn_league.settings.draftSettings.auctionBudget
 
+        # Preserve upstream league name from ESPN settings
+        league_name = None
+        if espn_league.settings:
+            league_name = espn_league.settings.name
+
         return MtblLeagueModel(
             league_id=espn_league.id,
+            league_name=league_name,
             season_id=espn_league.seasonId,
             scoring_period_id=espn_league.scoringPeriodId,
             num_teams=len(espn_league.teams),
@@ -390,6 +398,34 @@ class LeagueTransformer:
             acquisition_budget=acquisition_budget,
             draft_auction_budget=draft_auction_budget,
         )
+
+    @staticmethod
+    def _extract_team_categories(
+        matchup: EspnScheduleMatchupModel, team_key: Optional[str]
+    ) -> Optional[List[CategoryResultModel]]:
+        """
+        Extract a team's per-category results from an ESPN matchup.
+
+        Args:
+            matchup: ESPN schedule matchup
+            team_key: Team ID as a string key (categoryResults is keyed by
+                stringified team IDs, matching the ``teams`` mapping)
+
+        Returns:
+            List of CategoryResultModel, or None for points/roster-limit
+            leagues where ESPN provides no per-category breakdown
+        """
+        if not matchup.categoryResults or team_key is None:
+            return None
+        team_categories = matchup.categoryResults.get(team_key)
+        if not team_categories:
+            return None
+        return [
+            CategoryResultModel(
+                category=name, value=result.value, result=result.result
+            )
+            for name, result in team_categories.items()
+        ]
 
     @classmethod
     def transform_schedule(cls, espn_league: EspnLeagueModel) -> MtblScheduleModel:
@@ -413,10 +449,17 @@ class LeagueTransformer:
             team_ids = list(matchup.teams.keys())
             is_bye = matchup.winner == "BYE WEEK"
 
-            team1_id = int(team_ids[0]) if team_ids else None
-            team1_score = matchup.teams.get(team_ids[0]) if team_ids else None
-            team2_id = int(team_ids[1]) if len(team_ids) > 1 else None
-            team2_score = matchup.teams.get(team_ids[1]) if len(team_ids) > 1 else None
+            team1_key = team_ids[0] if team_ids else None
+            team2_key = team_ids[1] if len(team_ids) > 1 else None
+
+            team1_id = int(team1_key) if team1_key else None
+            team1_score = matchup.teams.get(team1_key) if team1_key else None
+            team2_id = int(team2_key) if team2_key else None
+            team2_score = matchup.teams.get(team2_key) if team2_key else None
+
+            # Per-category breakdown (H2H category leagues only)
+            team1_categories = cls._extract_team_categories(matchup, team1_key)
+            team2_categories = cls._extract_team_categories(matchup, team2_key)
 
             # Parse winner
             winner_id = None
@@ -434,6 +477,8 @@ class LeagueTransformer:
                     team2_score=team2_score,
                     winner_id=winner_id,
                     is_bye_week=is_bye,
+                    team1_categories=team1_categories,
+                    team2_categories=team2_categories,
                 )
             )
 

--- a/tests/transformers/test_league_transformer.py
+++ b/tests/transformers/test_league_transformer.py
@@ -4,6 +4,7 @@ from player_universe_trx.transformers import league_transformer
 from player_universe_trx.models.espn import EspnLeagueModel, EspnRosterModel, EspnTeamModel
 from player_universe_trx.models.espn.league import (
     EspnAcquisitionSettingsModel,
+    EspnCategoryResultModel,
     EspnDraftSettingsModel,
     EspnLeagueSettingsModel,
     EspnPlayerMinimalModel,
@@ -274,6 +275,35 @@ def test_create_league_summary_with_and_without_settings():
     assert summary_none.draft_auction_budget is None
 
 
+def test_create_league_summary_preserves_league_name():
+    # Name survives the ESPN settings -> MTBL summary boundary
+    settings = EspnLeagueSettingsModel(name="The Merican Fantasy Invitational")
+    league = EspnLeagueModel(id=7, seasonId=2025, teams=[], settings=settings)
+    summary = LeagueTransformer.create_league_summary(league)
+    assert summary.league_name == "The Merican Fantasy Invitational"
+
+    # No settings block -> league_name is None, not an error
+    league_no_settings = EspnLeagueModel(id=8, seasonId=2025, teams=[], settings=None)
+    assert (
+        LeagueTransformer.create_league_summary(league_no_settings).league_name is None
+    )
+
+    # Settings present but name absent -> None
+    settings_no_name = EspnLeagueSettingsModel(
+        acquisitionSettings=EspnAcquisitionSettingsModel(acquisitionBudget=100)
+    )
+    league_no_name = EspnLeagueModel(
+        id=9, seasonId=2025, teams=[], settings=settings_no_name
+    )
+    assert (
+        LeagueTransformer.create_league_summary(league_no_name).league_name is None
+    )
+
+    # Raw-dict parse: ESPN puts the league name at settings.name
+    parsed = EspnLeagueSettingsModel.model_validate({"name": "Raw League"})
+    assert parsed.name == "Raw League"
+
+
 def test_transform_schedule_playoff_and_bye_week():
     matchup_regular = EspnScheduleMatchupModel(
         id=1,
@@ -312,3 +342,74 @@ def test_transform_schedule_playoff_and_bye_week():
     assert second.team2_id is None
     assert second.winner_id is None
     assert second.is_bye_week is True
+
+    # No categoryResults upstream -> per-category fields stay None
+    assert first.team1_categories is None
+    assert first.team2_categories is None
+
+
+def test_transform_schedule_category_breakdown():
+    matchup = EspnScheduleMatchupModel(
+        id=1,
+        matchupPeriodId=3,
+        playoffTierType="NONE",
+        winner=31,
+        teams={"31": "7-5-0", "1": "5-7-0"},
+        categoryResults={
+            "31": {
+                "R": EspnCategoryResultModel(value=45, result="WIN"),
+                "HR": EspnCategoryResultModel(value=12, result="LOSS"),
+            },
+            "1": {
+                "R": EspnCategoryResultModel(value=40, result="LOSS"),
+                "HR": EspnCategoryResultModel(value=15, result="WIN"),
+            },
+        },
+    )
+    league = EspnLeagueModel(id=1, seasonId=2025, teams=[], schedule=[matchup])
+
+    schedule = LeagueTransformer.transform_schedule(league)
+    m = schedule.matchups[0]
+
+    assert m.team1_categories is not None
+    assert {c.category: c.result for c in m.team1_categories} == {
+        "R": "WIN",
+        "HR": "LOSS",
+    }
+    assert {c.category: c.value for c in m.team1_categories} == {
+        "R": 45.0,
+        "HR": 12.0,
+    }
+    assert {c.category: c.result for c in m.team2_categories} == {
+        "R": "LOSS",
+        "HR": "WIN",
+    }
+
+    # categoryResults parses from a raw dict via the camelCase alias
+    parsed = EspnScheduleMatchupModel.model_validate(
+        {
+            "id": 2,
+            "matchupPeriodId": 3,
+            "winner": 5,
+            "teams": {"5": "6-6-0", "6": "6-6-0"},
+            "categoryResults": {
+                "5": {"SB": {"value": 8, "result": "TIE"}},
+            },
+        }
+    )
+    assert parsed.categoryResults["5"]["SB"].result == "TIE"
+
+
+def test_transform_schedule_without_category_results():
+    # Points / roster-limit leagues have no categoryResults -> fields are None
+    matchup = EspnScheduleMatchupModel(
+        id=1,
+        matchupPeriodId=1,
+        winner=1,
+        teams={"1": "5-3", "2": "3-5"},
+    )
+    league = EspnLeagueModel(id=1, seasonId=2025, teams=[], schedule=[matchup])
+
+    m = LeagueTransformer.transform_schedule(league).matchups[0]
+    assert m.team1_categories is None
+    assert m.team2_categories is None

--- a/tests/transformers/test_league_transformer.py
+++ b/tests/transformers/test_league_transformer.py
@@ -399,6 +399,19 @@ def test_transform_schedule_category_breakdown():
     )
     assert parsed.categoryResults["5"]["SB"].result == "TIE"
 
+    # categoryResults present but missing one team's entry -> that team is None
+    partial = EspnScheduleMatchupModel(
+        id=3,
+        matchupPeriodId=3,
+        winner=9,
+        teams={"9": "8-4-0", "10": "4-8-0"},
+        categoryResults={"9": {"R": EspnCategoryResultModel(value=50, result="WIN")}},
+    )
+    partial_league = EspnLeagueModel(id=1, seasonId=2025, teams=[], schedule=[partial])
+    partial_m = LeagueTransformer.transform_schedule(partial_league).matchups[0]
+    assert partial_m.team1_categories is not None
+    assert partial_m.team2_categories is None
+
 
 def test_transform_schedule_without_category_results():
     # Points / roster-limit leagues have no categoryResults -> fields are None


### PR DESCRIPTION
## Summary
Two upstream fields were silently lost at the Pydantic model boundary — unmodeled keys are discarded on parse. This declares them on both the ESPN source models and the MTBL target models, and wires them through the transformer.

### 1. League name
- `EspnLeagueSettingsModel` gains a `name` field — ESPN puts the league name at `settings.name`.
- `MtblLeagueModel` gains `league_name`; `create_league_summary` wires it through so `league_<id>_summary.json` retains the upstream name (e.g. `"The Merican Fantasy Invitational"`).

### 2. Per-category matchup breakdown
Previously the schedule output only carried the final line (`7-5-0`). Now it carries *how each category performed*.
- New `EspnCategoryResultModel`; `EspnScheduleMatchupModel` gains `categoryResults`, matching the extractor's new output.
- New `CategoryResultModel`; `ScheduleMatchupModel` gains `team1_categories` / `team2_categories`.
- `transform_schedule` maps the per-category WIN/LOSS/TIE results via the new `_extract_team_categories` helper. Fields stay `None` for points/roster-limit leagues with no category data.

## Example output
```json
"team1_categories": [
  {"category": "R",   "value": 52.0, "result": "WIN"},
  {"category": "HR",  "value": 9.0,  "result": "LOSS"},
  {"category": "ERA", "value": 3.41, "result": "WIN"}
]
```

## Dependency
Requires **MTBLL/ESPN_API_Extractor#18** for the upstream `categoryResults` field. The transform handles its absence gracefully — older dumped files (no `categoryResults`) parse fine with the new fields left `None`.

## Tests
- `test_create_league_summary_preserves_league_name`
- `test_transform_schedule_category_breakdown`, `test_transform_schedule_without_category_results`
- Full suite: 231 passed. mypy: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)