### PR TITLE
fix: resolve matchup categories to names instead of stat_ids

### DIFF
--- a/player_universe_trx/transformers/league_transformer.py
+++ b/player_universe_trx/transformers/league_transformer.py
@@ -400,8 +400,68 @@ class LeagueTransformer:
         )
 
     @staticmethod
+    def _build_category_name_map(espn_league: EspnLeagueModel) -> Dict[str, str]:
+        """
+        Map stringified ESPN ``stat_id`` -> category name from league scoring
+        settings.
+
+        These are the same statId/name pairs that feed
+        ``league_scoring_categories``; reusing them keeps matchup categories
+        named consistently with every other category surface.
+
+        Args:
+            espn_league: ESPN league model
+
+        Returns:
+            Dict of ``str(stat_id)`` -> category name; empty when the league
+            carries no scoring settings (points/roster-limit leagues)
+        """
+        name_map: Dict[str, str] = {}
+        if espn_league.settings and espn_league.settings.scoringSettings:
+            categories = espn_league.settings.scoringSettings.categories
+            for cat in (*categories.batting, *categories.pitching):
+                name_map[str(cat.statId)] = cat.name
+        return name_map
+
+    @staticmethod
+    def _resolve_category_name(key: str, name_map: Dict[str, str]) -> str:
+        """
+        Resolve a ``categoryResults`` inner key to a category name.
+
+        Upstream ESPN extracts now key the per-category breakdown by numeric
+        ``stat_id`` (e.g. ``"20"``, ``"5"``); older exports keyed by name
+        (``"R"``, ``"HR"``). Numeric keys are resolved via the league's
+        scoring-category map. Any non-numeric key -- a name from an older
+        export, or the ``"BYE"`` sentinel -- passes through unchanged. An
+        unmapped numeric key falls back to the raw id so data is never
+        silently dropped.
+
+        Args:
+            key: Raw ``categoryResults`` inner key
+            name_map: ``str(stat_id)`` -> name map from
+                :meth:`_build_category_name_map`
+
+        Returns:
+            The resolved category name
+        """
+        if not key.isdigit():
+            return key
+        resolved = name_map.get(key)
+        if resolved is None:
+            logger.warning(
+                "matchup category stat_id %s not in league scoring "
+                "settings; emitting raw id",
+                key,
+            )
+            return key
+        return resolved
+
+    @classmethod
     def _extract_team_categories(
-        matchup: EspnScheduleMatchupModel, team_key: Optional[str]
+        cls,
+        matchup: EspnScheduleMatchupModel,
+        team_key: Optional[str],
+        category_name_map: Dict[str, str],
     ) -> Optional[List[CategoryResultModel]]:
         """
         Extract a team's per-category results from an ESPN matchup.
@@ -410,6 +470,8 @@ class LeagueTransformer:
             matchup: ESPN schedule matchup
             team_key: Team ID as a string key (categoryResults is keyed by
                 stringified team IDs, matching the ``teams`` mapping)
+            category_name_map: ``str(stat_id)`` -> name map used to resolve
+                numeric category keys back to names
 
         Returns:
             List of CategoryResultModel, or None for points/roster-limit
@@ -422,9 +484,11 @@ class LeagueTransformer:
             return None
         return [
             CategoryResultModel(
-                category=name, value=result.value, result=result.result
+                category=cls._resolve_category_name(key, category_name_map),
+                value=result.value,
+                result=result.result,
             )
-            for name, result in team_categories.items()
+            for key, result in team_categories.items()
         ]
 
     @classmethod
@@ -439,6 +503,7 @@ class LeagueTransformer:
             MtblScheduleModel with matchups
         """
         matchups = []
+        category_name_map = cls._build_category_name_map(espn_league)
         for matchup in espn_league.schedule:
             # Determine if this is a playoff matchup
             is_playoff = (
@@ -458,8 +523,12 @@ class LeagueTransformer:
             team2_score = matchup.teams.get(team2_key) if team2_key else None
 
             # Per-category breakdown (H2H category leagues only)
-            team1_categories = cls._extract_team_categories(matchup, team1_key)
-            team2_categories = cls._extract_team_categories(matchup, team2_key)
+            team1_categories = cls._extract_team_categories(
+                matchup, team1_key, category_name_map
+            )
+            team2_categories = cls._extract_team_categories(
+                matchup, team2_key, category_name_map
+            )
 
             # Parse winner
             winner_id = None

--- a/tests/transformers/test_league_transformer.py
+++ b/tests/transformers/test_league_transformer.py
@@ -413,6 +413,78 @@ def test_transform_schedule_category_breakdown():
     assert partial_m.team2_categories is None
 
 
+def test_transform_schedule_resolves_numeric_stat_ids():
+    # Latest ESPN extracts key categoryResults by numeric stat_id; the
+    # transformer resolves those back to category names via the league's
+    # scoring settings (the source of league_scoring_categories).
+    settings = EspnLeagueSettingsModel(
+        scoringSettings=EspnScoringSettingsModel(
+            categories=EspnScoringCategoriesModel(
+                batting=[
+                    EspnScoringCategoryModel(statId=20, name="R"),
+                    EspnScoringCategoryModel(statId=5, name="HR"),
+                ],
+                pitching=[
+                    EspnScoringCategoryModel(statId=47, name="ERA"),
+                ],
+            )
+        )
+    )
+    matchup = EspnScheduleMatchupModel(
+        id=48,
+        matchupPeriodId=10,
+        winner=1,
+        teams={"1": "8-4-0", "2": "4-8-0"},
+        categoryResults={
+            "1": {
+                "20": EspnCategoryResultModel(value=18, result="WIN"),
+                "5": EspnCategoryResultModel(value=7, result="LOSS"),
+                "47": EspnCategoryResultModel(value=1.373, result="WIN"),
+                # unmapped numeric stat_id -> falls back to the raw id, never dropped
+                "999": EspnCategoryResultModel(value=1, result="TIE"),
+                # non-numeric sentinel -> passes through unchanged
+                "BYE": EspnCategoryResultModel(value=None, result=None),
+            },
+        },
+    )
+    league = EspnLeagueModel(
+        id=1, seasonId=2026, teams=[], schedule=[matchup], settings=settings
+    )
+
+    m = LeagueTransformer.transform_schedule(league).matchups[0]
+    assert {c.category: c.result for c in m.team1_categories} == {
+        "R": "WIN",
+        "HR": "LOSS",
+        "ERA": "WIN",
+        "999": "TIE",
+        "BYE": None,
+    }
+
+
+def test_transform_schedule_category_breakdown_no_scoring_settings():
+    # Without scoring settings the name map is empty; numeric keys fall back
+    # to the raw id, name keys still pass through (backward compatible).
+    matchup = EspnScheduleMatchupModel(
+        id=1,
+        matchupPeriodId=3,
+        winner=1,
+        teams={"1": "1-1-0", "2": "1-1-0"},
+        categoryResults={
+            "1": {
+                "20": EspnCategoryResultModel(value=18, result="WIN"),
+                "HR": EspnCategoryResultModel(value=7, result="LOSS"),
+            },
+        },
+    )
+    league = EspnLeagueModel(id=1, seasonId=2026, teams=[], schedule=[matchup])
+
+    m = LeagueTransformer.transform_schedule(league).matchups[0]
+    assert {c.category: c.result for c in m.team1_categories} == {
+        "20": "WIN",
+        "HR": "LOSS",
+    }
+
+
 def test_transform_schedule_without_category_results():
     # Points / roster-limit leagues have no categoryResults -> fields are None
     matchup = EspnScheduleMatchupModel(


### PR DESCRIPTION
## Problem

The latest ESPN extract keys `categoryResults` per-category breakdowns by numeric `stat_id` (e.g. `"20"`, `"5"`) rather than category names (`"R"`, `"HR"`). `_extract_team_categories` passed those keys straight into `CategoryResultModel.category`, so `matchup_categories.category` regressed from names to raw stat_ids.

The viz consumer (`matchupCategories` query + `MatchupCard` breakdown table) matches `category` **by name**, so the matchup-card category breakdown stopped rendering.

### Evidence — matchup 48, team 1

| `category` (regressed) | value | should be |
|---|---|---|
| `17` | 0.351 | OBP |
| `20` | 18 | R |
| `5`  | 7 | HR |
| `47` | 1.373 | ERA |
| `83` | 6 | SVHD |
| … | | |

## Fix

`transform_schedule` now builds a `str(stat_id) -> name` map from the league's own `scoringSettings.categories` (batting + pitching) — the same `statId`/`name` pairs that feed `league_scoring_categories`. `_extract_team_categories` resolves each `categoryResults` key through it.

Resolution is **backward compatible**:
- Numeric keys (`"20"`) → resolved to the name (`R`).
- Non-numeric keys — older name-keyed exports (`"R"`) and the `"BYE"` sentinel — pass through unchanged.
- An unmapped numeric id falls back to the raw id (logged `warning`) so data is never silently dropped.
- Leagues with no scoring settings (points/roster-limit) yield an empty map; numeric keys fall back to raw ids, names still pass through.

## Tests

- `test_transform_schedule_resolves_numeric_stat_ids` — numeric ids resolve to names; unmapped id + `BYE` sentinel pass through.
- `test_transform_schedule_category_breakdown_no_scoring_settings` — empty map fallback.
- Existing name-keyed tests unchanged (backward compat).

233 tests pass, mypy clean, **100% coverage** on `league_transformer.py`.

## Viz side

No change needed — once the export emits names again, the `MatchupCard` breakdown renders with no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)