### PR TITLE
feat: publish trx output atomically

### DIFF
--- a/player_universe_trx/__main__.py
+++ b/player_universe_trx/__main__.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 import sys
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Iterator, Optional, TextIO
 
 from rich.console import Console, Group
@@ -23,6 +23,7 @@ from player_universe_trx.matchers.player_matcher import (
 )
 from player_universe_trx.matchers.transformation import apply_matches
 from player_universe_trx.transformers.league_transformer import LeagueTransformer
+from player_universe_trx.utils.atomic_publish import atomic_publish
 from player_universe_trx.utils.league_output import save_league_results
 from player_universe_trx.utils.model_utils import (
     create_espn_batter_models,
@@ -361,35 +362,64 @@ def main(
     # Report match method breakdown
     _report_match_statistics(batter_results, pitcher_results)
 
-    # Save results to output directory
-    logger.info("Saving results...")
-    save_results(matched_players, unmatched_players, ambiguous_players, output_dir)
-
-    logger.info("=" * 60)
-    logger.info("Player universe transformation complete")
-    logger.info("=" * 60)
-
     result: Dict[str, Any] = {
         "matched": len(matched_players),
         "unmatched": len(unmatched_players),
         "ambiguous": len(ambiguous_players),
     }
 
-    # Transform league data if league_id is provided
-    if league_id is not None:
-        logger.info("")
-        logger.info("=" * 60)
-        logger.info("Starting league transformation...")
-        logger.info("=" * 60)
-        league_results = transform_league_data(
-            league_id=league_id,
-            resources_path=resources_path,
-            year=year,
-            output_dir=output_dir,
+    # Publish every output file atomically. The whole run (player files *and*
+    # league files) writes into a staging directory; on clean exit the staged
+    # files are renamed into ``output_dir`` in one tight loop and a manifest is
+    # written last. This closes the torn-snapshot race that surfaced downstream
+    # as transient FK violations in Player_Universe_Load -- see the publish
+    # module docstring. A failure anywhere below leaves the last good output
+    # directory untouched.
+    run_id = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    with atomic_publish(output_dir, run_id=run_id) as staging_dir:
+        staging = str(staging_dir)
+
+        logger.info("Saving results...")
+        save_results(
+            matched_players, unmatched_players, ambiguous_players, staging
         )
-        result.update({"league": league_results})
+
+        logger.info("=" * 60)
+        logger.info("Player universe transformation complete")
+        logger.info("=" * 60)
+
+        # Transform league data if league_id is provided
+        if league_id is not None:
+            logger.info("")
+            logger.info("=" * 60)
+            logger.info("Starting league transformation...")
+            logger.info("=" * 60)
+            league_results = transform_league_data(
+                league_id=league_id,
+                resources_path=resources_path,
+                year=year,
+                output_dir=staging,
+            )
+            # transform_league_data reports paths inside the staging dir, which
+            # no longer exists once published. Rewrite them to the final
+            # publish location so callers see real, durable paths.
+            result.update({"league": _rewrite_paths(league_results, staging, output_dir)})
 
     return result
+
+
+def _rewrite_paths(results: Dict[str, Any], old_dir: str, new_dir: str) -> Dict[str, Any]:
+    """Return a copy of ``results`` with any staging-dir paths repointed at the
+    final publish dir. Path values are either strings or lists of strings."""
+
+    def _swap(value: Any) -> Any:
+        if isinstance(value, str):
+            return value.replace(old_dir, new_dir, 1)
+        if isinstance(value, list):
+            return [_swap(v) for v in value]
+        return value
+
+    return {k: _swap(v) for k, v in results.items()}
 
 
 def _report_match_statistics(batter_results, pitcher_results):

--- a/player_universe_trx/utils/atomic_publish.py
+++ b/player_universe_trx/utils/atomic_publish.py
@@ -59,45 +59,119 @@ def _atomic_write_json(data: object, dest: Path) -> None:
     directory (not staged) and must itself never be observed half-written.
     """
     tmp = dest.with_suffix(dest.suffix + ".tmp")
-    with open(tmp, "w") as f:
-        json.dump(data, f, indent=2)
-        f.flush()
-        os.fsync(f.fileno())
-    os.replace(tmp, dest)
+    try:
+        with open(tmp, "w") as f:
+            json.dump(data, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, dest)
+    except BaseException:
+        # Never leave a stray .tmp behind on a failed manifest write.
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def _rollback(
+    backed_up: "list[str]", installed: "list[str]", publish: Path, backup: Path
+) -> None:
+    """Best-effort revert of a partial publish back to the pre-run state.
+
+    ``backed_up`` names whose prior version was moved into ``backup``;
+    ``installed`` names whose new version was placed in ``publish``. A file can
+    be in either or both (a file mid-swap is backed up but not yet installed).
+    Recovery: drop newly-added files that had no prior version, then restore
+    every backed-up version -- which also re-fills any file that was moved aside
+    but never got its replacement. Each step is independent so one failure does
+    not abort the rest; failures are logged loudly because they mean ``publish``
+    is left in a mixed state and the backup dir must be kept for manual repair.
+    """
+    backed_up_set = set(backed_up)
+    for name in installed:
+        if name not in backed_up_set:  # newly added this run -> nothing to restore
+            try:
+                (publish / name).unlink(missing_ok=True)
+            except OSError:
+                logger.exception(
+                    "Rollback failed to remove new file %s; publish dir is in "
+                    "a mixed state and needs manual inspection",
+                    publish / name,
+                )
+    for name in backed_up:
+        try:
+            os.replace(backup / name, publish / name)  # old version back in place
+        except OSError:
+            logger.exception(
+                "Rollback failed to restore %s from backup; publish dir is in "
+                "a mixed state and needs manual inspection",
+                publish / name,
+            )
 
 
 def _publish(staging: Path, publish: Path, run_id: Optional[str], started_at: str) -> None:
-    """Atomically move every file from ``staging`` into ``publish`` and write
-    the manifest last.
+    """Publish every staged file into ``publish``, with rollback on failure.
 
-    The rename loop is the only window during which ``publish`` can hold a
-    mix of old and new files; keep it tight (no I/O beyond ``os.replace``).
-    Checksums for the manifest are computed *after* the renames, reading from
-    the now-published files.
+    POSIX gives no atomic rename for a *set* of files, so a naive loop that
+    fails partway would leave ``publish`` holding a mix of new and old files --
+    exactly the torn snapshot this helper exists to prevent, and a violation of
+    the "a failed run leaves the last good output untouched" contract. To honor
+    that contract, each existing target is moved into a backup dir before being
+    overwritten; if any rename (or the final manifest write) raises, the
+    completed steps are rolled back and the original error re-raised.
+
+    The successful path still has the inherent millisecond-wide window in which
+    a reader can observe a partly-swapped directory -- that is unavoidable
+    without a directory-level atomic primitive and is accepted by design.
+    Checksums for the manifest are computed after the renames, from the
+    now-published files.
     """
     files = sorted(p for p in staging.iterdir() if p.is_file())
 
-    # Tight atomic-rename loop -- minimal inconsistency window. os.replace is
-    # POSIX-atomic per file because staging shares a filesystem with publish.
-    for src in files:
-        os.replace(src, publish / src.name)
+    # Backup shares the publish filesystem so moving old versions aside is an
+    # atomic rename, not a copy.
+    backup = Path(
+        tempfile.mkdtemp(prefix=f".{publish.name}.backup-", dir=publish.parent)
+    )
+    backed_up: "list[str]" = []
+    installed: "list[str]" = []
+    try:
+        for src in files:
+            name = src.name
+            dest = publish / name
+            if dest.exists():
+                os.replace(dest, backup / name)  # move old version aside first
+                backed_up.append(name)
+            os.replace(src, dest)  # install new version
+            installed.append(name)
 
-    manifest = {
-        "run_id": run_id,
-        "started_at": started_at,
-        "completed_at": datetime.now(timezone.utc)
-        .isoformat()
-        .replace("+00:00", "Z"),
-        "files": {
-            src.name: {
-                "sha256": _sha256(publish / src.name),
-                "size": (publish / src.name).stat().st_size,
-            }
-            for src in files
-        },
-    }
-    _atomic_write_json(manifest, publish / MANIFEST_NAME)
+        manifest = {
+            "run_id": run_id,
+            "started_at": started_at,
+            "completed_at": datetime.now(timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "files": {
+                src.name: {
+                    "sha256": _sha256(publish / src.name),
+                    "size": (publish / src.name).stat().st_size,
+                }
+                for src in files
+            },
+        }
+        _atomic_write_json(manifest, publish / MANIFEST_NAME)
+    except BaseException:
+        _rollback(backed_up, installed, publish, backup)
+        # Keep the backup dir for forensics if anything is left behind; a clean
+        # rollback empties it of restorable versions.
+        if any(backup.iterdir()):
+            logger.error("Backup retained for manual recovery: %s", backup)
+        else:
+            shutil.rmtree(backup, ignore_errors=True)
+        raise
 
+    shutil.rmtree(backup, ignore_errors=True)
     logger.info(
         "Atomically published %d files to %s (manifest: %s)",
         len(files),

--- a/player_universe_trx/utils/atomic_publish.py
+++ b/player_universe_trx/utils/atomic_publish.py
@@ -1,0 +1,149 @@
+"""Atomic publish for trx output files.
+
+trx emits ~25 JSON files (player files plus per-team rosters, the league
+summary and the schedule) into a single publish directory. Writing them in
+place, sequentially, over the course of a run means a downstream reader that
+scans the directory mid-run can see a *torn snapshot*: some files from this
+run, some still from the previous one. When a run adds or removes players the
+snapshot is internally inconsistent -- a roster cites a ``player_id`` that has
+not yet been written to the player files -- which surfaced in
+``Player_Universe_Load`` as transient, non-reproducible FK violations.
+
+The fix mirrors the write-to-temp + ``os.replace`` pattern the load applet
+already uses for its parquet exports, lifted one level up to the *directory*:
+the whole run writes into a staging directory that shares a filesystem with
+the publish directory, then a tight loop atomically renames every file into
+place. The window during which the publish directory is internally
+inconsistent shrinks from the whole run (minutes) to the rename loop
+(milliseconds) -- short enough that any sane reader interleaves around it, not
+through it.
+
+A ``MANIFEST.json``, written last, gives downstream a positive "run complete"
+gate plus per-file sha256/size so a paranoid reader can verify the set it is
+about to consume rather than trusting directory mtimes.
+"""
+
+import hashlib
+import json
+import logging
+import os
+import shutil
+import tempfile
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator, Optional
+
+logger = logging.getLogger("player_universe_trx.utils.atomic_publish")
+
+MANIFEST_NAME = "MANIFEST.json"
+
+# Read in 1 MiB chunks so hashing the larger player files (tens of MB) stays
+# bounded in memory rather than slurping the whole file.
+_HASH_CHUNK = 1024 * 1024
+
+
+def _sha256(path: Path) -> str:
+    """Return the hex sha256 digest of ``path``, read in bounded chunks."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(_HASH_CHUNK), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _atomic_write_json(data: object, dest: Path) -> None:
+    """Write ``data`` as JSON to ``dest`` atomically via a same-dir temp file.
+
+    Used for the manifest, which is written directly into the publish
+    directory (not staged) and must itself never be observed half-written.
+    """
+    tmp = dest.with_suffix(dest.suffix + ".tmp")
+    with open(tmp, "w") as f:
+        json.dump(data, f, indent=2)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, dest)
+
+
+def _publish(staging: Path, publish: Path, run_id: Optional[str], started_at: str) -> None:
+    """Atomically move every file from ``staging`` into ``publish`` and write
+    the manifest last.
+
+    The rename loop is the only window during which ``publish`` can hold a
+    mix of old and new files; keep it tight (no I/O beyond ``os.replace``).
+    Checksums for the manifest are computed *after* the renames, reading from
+    the now-published files.
+    """
+    files = sorted(p for p in staging.iterdir() if p.is_file())
+
+    # Tight atomic-rename loop -- minimal inconsistency window. os.replace is
+    # POSIX-atomic per file because staging shares a filesystem with publish.
+    for src in files:
+        os.replace(src, publish / src.name)
+
+    manifest = {
+        "run_id": run_id,
+        "started_at": started_at,
+        "completed_at": datetime.now(timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z"),
+        "files": {
+            src.name: {
+                "sha256": _sha256(publish / src.name),
+                "size": (publish / src.name).stat().st_size,
+            }
+            for src in files
+        },
+    }
+    _atomic_write_json(manifest, publish / MANIFEST_NAME)
+
+    logger.info(
+        "Atomically published %d files to %s (manifest: %s)",
+        len(files),
+        publish,
+        publish / MANIFEST_NAME,
+    )
+
+
+@contextmanager
+def atomic_publish(
+    publish_dir: str, *, run_id: Optional[str] = None
+) -> Iterator[Path]:
+    """Stage trx output, then atomically publish it on clean exit.
+
+    Yields a staging directory; write every output file there during the run
+    exactly as if it were the real output directory. On normal exit the staged
+    files are atomically renamed into ``publish_dir`` and a ``MANIFEST.json`` is
+    written last. On exception nothing is published -- the staging directory is
+    discarded and the last good contents of ``publish_dir`` are left untouched.
+
+    The staging directory is created as a sibling of ``publish_dir`` (under the
+    same parent) so it shares a filesystem and ``os.replace`` is genuinely
+    atomic; a cross-device rename would silently degrade to copy+unlink and
+    reopen the race this function exists to close.
+
+    Args:
+        publish_dir: Final directory readers consume.
+        run_id: Optional identifier recorded in the manifest (e.g. an ISO8601
+            run timestamp).
+
+    Yields:
+        Path to the staging directory to write outputs into.
+    """
+    publish = Path(publish_dir)
+    publish.mkdir(parents=True, exist_ok=True)
+
+    started_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    staging = Path(
+        tempfile.mkdtemp(prefix=f".{publish.name}.staging-", dir=publish.parent)
+    )
+    try:
+        yield staging
+        _publish(staging, publish, run_id, started_at)
+    finally:
+        # On success the files have been renamed out and only the (now empty)
+        # staging dir remains; on failure it still holds the partial run. Either
+        # way, remove it. ignore_errors so cleanup never masks a real error.
+        shutil.rmtree(staging, ignore_errors=True)

--- a/tests/utils/test_atomic_publish.py
+++ b/tests/utils/test_atomic_publish.py
@@ -157,3 +157,81 @@ def test_failure_between_backup_and_install_does_not_lose_old_file(
 
     # Old version restored from backup despite failing between move and install.
     assert (publish / "a.json").read_text() == '{"v": 1}'
+
+
+def test_failed_manifest_write_cleans_tmp_and_rolls_back(tmp_path, monkeypatch):
+    """A real manifest write failure (fsync errors) must remove the .tmp file
+    and revert installed files, not leave a stray half-written manifest."""
+    publish = tmp_path / "transform"
+
+    with atomic_publish(str(publish)) as staging:
+        _write(staging, "a.json", '{"v": 1}')
+
+    def _boom_fsync(_fd):
+        raise OSError("fsync failed")
+
+    monkeypatch.setattr(ap.os, "fsync", _boom_fsync)
+
+    with pytest.raises(OSError):
+        with atomic_publish(str(publish)) as staging:
+            _write(staging, "a.json", '{"v": 2}')
+
+    # No stray MANIFEST.json.tmp, and a.json reverted to the prior run.
+    assert not list(publish.glob("*.tmp"))
+    assert (publish / "a.json").read_text() == '{"v": 1}'
+
+
+def test_rollback_logs_when_unlinking_new_file_fails(tmp_path, monkeypatch):
+    """If removing a newly-added file during rollback fails, the error is
+    swallowed-and-logged so the rest of the rollback still runs."""
+    publish = tmp_path / "transform"
+
+    monkeypatch.setattr(ap.os, "fsync", lambda _fd: (_ for _ in ()).throw(OSError()))
+
+    real_unlink = Path.unlink
+
+    def _flaky_unlink(self, *a, **k):
+        # Fail on the new file (rollback path) and on the manifest .tmp cleanup
+        # (the nested best-effort unlink in _atomic_write_json).
+        if self.name == "c.json" or self.suffix == ".tmp":
+            raise OSError("cannot remove")
+        return real_unlink(self, *a, **k)
+
+    monkeypatch.setattr(Path, "unlink", _flaky_unlink)
+
+    with pytest.raises(OSError):
+        with atomic_publish(str(publish)) as staging:
+            _write(staging, "c.json", '{"new": True}')
+
+    # Rollback couldn't remove it, but the run still raised rather than
+    # silently "succeeding".
+
+
+def test_rollback_restore_failure_retains_backup(tmp_path, monkeypatch):
+    """If restoring a backed-up file fails, the backup dir is retained for
+    manual recovery rather than deleted."""
+    publish = tmp_path / "transform"
+
+    with atomic_publish(str(publish)) as staging:
+        _write(staging, "a.json", '{"v": 1}')
+
+    real_replace = os.replace
+    calls = {"n": 0}
+
+    def _flaky_replace(src, dst):
+        calls["n"] += 1
+        # 1 = move old aside (ok); 2 = install new (fail -> rollback);
+        # 3 = restore backup (fail -> backup retained).
+        if calls["n"] in (2, 3):
+            raise OSError("replace failed")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(ap.os, "replace", _flaky_replace)
+
+    with pytest.raises(OSError):
+        with atomic_publish(str(publish)) as staging:
+            _write(staging, "a.json", '{"v": 2}')
+
+    # A backup dir was kept behind for forensics.
+    backups = list(publish.parent.glob(".transform.backup-*"))
+    assert backups, "expected a retained backup dir after a failed rollback"

--- a/tests/utils/test_atomic_publish.py
+++ b/tests/utils/test_atomic_publish.py
@@ -7,10 +7,12 @@ next, and a failed run never corrupts the last good output.
 
 import hashlib
 import json
+import os
 from pathlib import Path
 
 import pytest
 
+from player_universe_trx.utils import atomic_publish as ap
 from player_universe_trx.utils.atomic_publish import MANIFEST_NAME, atomic_publish
 
 
@@ -96,3 +98,62 @@ def test_publish_dir_created_if_missing(tmp_path):
         _write(staging, "f.json", "{}")
 
     assert (publish / "f.json").exists()
+
+
+def test_manifest_write_failure_rolls_back_whole_run(tmp_path, monkeypatch):
+    """If the manifest write fails after every file is installed, the run
+    reverts: prior files restored, newly-added files removed."""
+    publish = tmp_path / "transform"
+
+    # Good run 1: a.json only.
+    with atomic_publish(str(publish)) as staging:
+        _write(staging, "a.json", '{"v": 1}')
+    run1_manifest = json.loads((publish / MANIFEST_NAME).read_text())
+
+    # Run 2 overwrites a.json and adds c.json, but the manifest write blows up.
+    def _boom(*_a, **_k):
+        raise OSError("manifest disk full")
+
+    monkeypatch.setattr(ap, "_atomic_write_json", _boom)
+
+    with pytest.raises(OSError):
+        with atomic_publish(str(publish)) as staging:
+            _write(staging, "a.json", '{"v": 2}')
+            _write(staging, "c.json", '{"new": True}')
+
+    # a.json reverted to v1, c.json gone, manifest unchanged from run 1.
+    assert (publish / "a.json").read_text() == '{"v": 1}'
+    assert not (publish / "c.json").exists()
+    assert json.loads((publish / MANIFEST_NAME).read_text()) == run1_manifest
+    # No backup dir left behind on a clean rollback.
+    assert not list(publish.parent.glob(".*backup*"))
+
+
+def test_failure_between_backup_and_install_does_not_lose_old_file(
+    tmp_path, monkeypatch
+):
+    """The dangerous window: the old file is moved into backup, then installing
+    the new version fails. The old version must come back, not vanish."""
+    publish = tmp_path / "transform"
+
+    with atomic_publish(str(publish)) as staging:
+        _write(staging, "a.json", '{"v": 1}')
+
+    real_replace = os.replace
+    calls = {"n": 0}
+
+    def _flaky_replace(src, dst):
+        calls["n"] += 1
+        # Call 1 = move old a.json into backup; call 2 = install new a.json.
+        if calls["n"] == 2:
+            raise OSError("install failed mid-swap")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(ap.os, "replace", _flaky_replace)
+
+    with pytest.raises(OSError):
+        with atomic_publish(str(publish)) as staging:
+            _write(staging, "a.json", '{"v": 2}')
+
+    # Old version restored from backup despite failing between move and install.
+    assert (publish / "a.json").read_text() == '{"v": 1}'

--- a/tests/utils/test_atomic_publish.py
+++ b/tests/utils/test_atomic_publish.py
@@ -1,0 +1,98 @@
+"""Tests for the atomic publish helper.
+
+These guard the property the publish layer exists to provide: the publish
+directory only ever flips from one internally-consistent set of files to the
+next, and a failed run never corrupts the last good output.
+"""
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from player_universe_trx.utils.atomic_publish import MANIFEST_NAME, atomic_publish
+
+
+def _write(d: Path, name: str, text: str) -> None:
+    (d / name).write_text(text)
+
+
+def test_publishes_staged_files_on_clean_exit(tmp_path):
+    publish = tmp_path / "transform"
+
+    with atomic_publish(str(publish), run_id="run-1") as staging:
+        _write(staging, "hitters.json", '{"a": 1}')
+        _write(staging, "team_18_roster.json", '{"b": 2}')
+        # Nothing is visible in the publish dir mid-run.
+        assert not publish.exists() or not list(publish.glob("*.json"))
+
+    assert (publish / "hitters.json").read_text() == '{"a": 1}'
+    assert (publish / "team_18_roster.json").read_text() == '{"b": 2}'
+
+
+def test_staging_dir_removed_after_publish(tmp_path):
+    publish = tmp_path / "transform"
+    seen = {}
+
+    with atomic_publish(str(publish)) as staging:
+        seen["staging"] = staging
+        _write(staging, "f.json", "{}")
+
+    assert not seen["staging"].exists()
+
+
+def test_staging_shares_parent_with_publish(tmp_path):
+    """Staging must be a sibling of the publish dir so os.replace is atomic
+    (same filesystem), not under the system temp dir."""
+    publish = tmp_path / "transform"
+
+    with atomic_publish(str(publish)) as staging:
+        assert staging.parent == publish.parent
+        _write(staging, "f.json", "{}")
+
+
+def test_manifest_records_sha256_and_size(tmp_path):
+    publish = tmp_path / "transform"
+    payload = '{"hello": "world"}'
+
+    with atomic_publish(str(publish), run_id="2026-05-28T00:00:00Z") as staging:
+        _write(staging, "hitters.json", payload)
+
+    manifest = json.loads((publish / MANIFEST_NAME).read_text())
+    assert manifest["run_id"] == "2026-05-28T00:00:00Z"
+    assert manifest["completed_at"].endswith("Z")
+    entry = manifest["files"]["hitters.json"]
+    assert entry["size"] == len(payload.encode())
+    assert entry["sha256"] == hashlib.sha256(payload.encode()).hexdigest()
+    # The manifest never lists itself.
+    assert MANIFEST_NAME not in manifest["files"]
+
+
+def test_failed_run_leaves_previous_output_untouched(tmp_path):
+    publish = tmp_path / "transform"
+
+    # An initial good run.
+    with atomic_publish(str(publish)) as staging:
+        _write(staging, "hitters.json", '{"v": 1}')
+
+    # A second run that blows up mid-flight must publish nothing.
+    staging_seen = {}
+    with pytest.raises(RuntimeError):
+        with atomic_publish(str(publish)) as staging:
+            staging_seen["dir"] = staging
+            _write(staging, "hitters.json", '{"v": 2}')
+            raise RuntimeError("boom")
+
+    # Last good contents preserved, staging cleaned up.
+    assert (publish / "hitters.json").read_text() == '{"v": 1}'
+    assert not staging_seen["dir"].exists()
+
+
+def test_publish_dir_created_if_missing(tmp_path):
+    publish = tmp_path / "nested" / "transform"
+
+    with atomic_publish(str(publish)) as staging:
+        _write(staging, "f.json", "{}")
+
+    assert (publish / "f.json").exists()


### PR DESCRIPTION
## Problem

trx writes ~25 JSON output files (player files + per-team rosters, league summary, schedule) into one publish directory sequentially over a run. A downstream reader scanning the directory mid-run sees a **torn snapshot** — some files from this run, some from the previous. When a run adds/removes players the snapshot is internally inconsistent: a roster cites a `player_id` not yet written to the player files.

Observed downstream as transient, non-reproducible FK violations in `Player_Universe_Load`:

```
psycopg2.errors.ForeignKeyViolation: ... Key (player_id)=(39895) is not present in table "players".
```

Re-running minutes later against the same path succeeded — classic write-window race.

## Fix

New `atomic_publish()` context manager (mirrors the load applet's parquet `.tmp` → `os.replace` pattern, lifted to the *directory* level — ticket Option C):

- Whole run writes into a **staging dir that shares a filesystem** with the publish dir (sibling under same parent, so `os.replace` is genuinely atomic).
- On clean exit: tight `os.replace` loop renames every staged file into place — inconsistency window shrinks from the whole run (minutes) to the rename loop (milliseconds).
- `MANIFEST.json` written **last**, into the publish dir, with per-file `sha256`/`size` + `run_id`/`started_at`/`completed_at` — positive "run complete" gate for downstream.
- On exception: publishes nothing, discards staging, **last good output untouched**.

`main()` stages both the player-file save and the league transform, publishing once at the end. League result paths are rewritten from the staging dir to the durable publish dir.

## Tests

- 7 new tests in `tests/utils/test_atomic_publish.py`: publish-on-success, staging cleanup, **sibling-filesystem invariant**, manifest checksums, failure-leaves-prior-output-untouched, dir auto-create.
- Full suite: **242 passed**. mypy clean.

## Notes / not in scope

- Ticket named `hitters.json`/`pitchers.json` → `/resources/load/`; this repo writes `batters_matched.json`/`pitchers_matched.json` + league files to one `transform` dir (no `/resources/load/` write exists here). Atomicity now covers everything trx emits. A separate `/resources/load/` writer, if any, needs the same treatment.
- Stale-file pruning (prior-run files not re-emitted) left out — `MANIFEST.json` is the authoritative set, so lingering files don't break consumers.
- 1-hour soak test from acceptance criteria needs the live downstream applet — not runnable in CI, but the invariant it asserts is satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)