### PR TITLE
feat: pass ESPN player news through transform pipeline to loader output

### DIFF
--- a/player_universe_trx/models/espn/espn_player.py
+++ b/player_universe_trx/models/espn/espn_player.py
@@ -1,6 +1,6 @@
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class BirthPlace(BaseModel):
@@ -111,5 +111,8 @@ class EspnPlayerModel(BaseModel):
 
     # Transactions
     transactions: Optional[List[Transaction]] = None
+
+    # News items from ESPN Fantasy news API (Rotowire notes)
+    news: List[Dict[str, Any]] = Field(default_factory=list)
 
     model_config = ConfigDict(populate_by_name=True)

--- a/player_universe_trx/models/mtbl/mtbl_player.py
+++ b/player_universe_trx/models/mtbl/mtbl_player.py
@@ -96,6 +96,9 @@ class MtblPlayerModel(BaseModel):
     # Media information
     headshot: Optional[str] = None
 
+    # News items from ESPN Fantasy news API (Rotowire notes)
+    news: List[Dict[str, Any]] = Field(default_factory=list)
+
     model_config = ConfigDict(
         populate_by_name=True, arbitrary_types_allowed=True, str_strip_whitespace=True
     )


### PR DESCRIPTION
## Summary

- Declares `news: List[Dict[str, Any]] = Field(default_factory=list)` on `EspnPlayerModel` and `MtblPlayerModel` so Rotowire news items fetched by the upstream ESPN_API_Extractor ([PR #20 — feature/player-news-hydration](https://github.com/MTBLL/ESPN_API_Extractor/pull/20)) survive the full transform pipeline
- Depends on ESPN_API_Extractor PR #20 being merged and the extractor re-run to produce extract files that include `news`

## Why both models need the field

Pydantic v2 silently drops undeclared fields at each model boundary (`extra="ignore"` by default). Without declaring `news` at every hop, the data is lost before it reaches the output JSON:

```
ESPN JSON → EspnPlayerModel.model_dump() → MtblPlayerModel.model_validate() → model_dump() → output JSON
```

Both `EspnPlayerModel` and `MtblPlayerModel` must declare the field for it to pass through.

## Downstream loader changes (Player_Universe_Load)

This PR's output JSON changes are already handled by a matching change in **Player_Universe_Load** (apply alongside this):

| File | Change |
|------|--------|
| `schemas/01_players.sql` | Added `news JSONB` column to `players` table |
| `loaders/players.py` | Added `json_serialize(player.get("news"))` to player insert tuple + `"news"` to column list |

The loader change must be deployed (schema re-initialized) before loading output from this transform version. `news` is stored as JSONB in the `players` table — same pattern as `eligible_slots` and `birth_place`.

## News data shape

Each item in `player.news`:

```json
{
  "id": 100803110,
  "headline": "Witt (knee) is back in the lineup...",
  "description": "...",
  "story": "Full Rotowire analysis paragraph...",
  "published": "2026-06-09T20:31:21Z",
  "type": "Rotowire"
}
```

Always present (empty `[]` when no news). Max 5 items per player (hardcoded `limit=5` in extractor).

## Real-data validation (espn_batters/pitchers_2026_20260611_172605.json)

| | With news | Total | Coverage |
|---|---|---|---|
| Batters | 1,378 | 1,870 | 73% |
| Pitchers | 1,572 | 1,934 | 81% |

Round-trip verified: ESPN JSON → `EspnBatterModel` → `MtblPlayerModel.model_dump()` preserves all 5 news items per player.

## Test plan

- [x] 247 transform tests pass (`uv run pytest`)
- [x] 95 loader tests pass
- [x] mypy clean (55 source files)
- [x] Real extract data confirmed: `news` key present, correct shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)